### PR TITLE
Fix writing negative bit size string and block data closes#121

### DIFF
--- a/ext/cosmos/ext/structure/structure.c
+++ b/ext/cosmos/ext/structure/structure.c
@@ -901,12 +901,14 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
 
       if (given_bit_size <= 0) {
         end_bytes = -(given_bit_size / 8);
-        /* If passed a huge negative bit_size we need to truncate end_bytes
-           to the size of the passed buffer to prevent overflow. */
-        if (end_bytes > buffer_length) {
-          end_bytes = buffer_length;
-        }
         old_upper_bound = buffer_length - 1 - end_bytes;
+        /* If the buffer is not already big enough to hold the non-variable sized items
+             that is a buffer error.  old_upper_bound can be -1 if the string is exactly the size of the
+             end_bytes which is ok */
+        if (old_upper_bound < -1) {
+          rb_funcall(self, id_method_raise_buffer_error, 5, symbol_write, param_buffer, param_data_type, param_bit_offset, param_bit_size);
+        }
+
         if (old_upper_bound < lower_bound) {
           /* String was completely empty */
           if (end_bytes > 0) {

--- a/ext/cosmos/ext/structure/structure.c
+++ b/ext/cosmos/ext/structure/structure.c
@@ -912,22 +912,18 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
         if (old_upper_bound < lower_bound) {
           /* String was completely empty */
           if (end_bytes > 0) {
-              printf("1");
             /* Preserve bytes at end of buffer */
             rb_str_concat(param_buffer, rb_str_times(ZERO_STRING, INT2FIX(value_length)));
             buffer = (unsigned char*) RSTRING_PTR(param_buffer);
             memmove((buffer + lower_bound + value_length), (buffer + lower_bound), end_bytes);
           }
         } else if (bit_size == 0) {
-            printf("2");
           /* Remove entire string */
           rb_str_update(param_buffer, lower_bound, old_upper_bound - lower_bound + 1, rb_str_new2(""));
         } else if (upper_bound < old_upper_bound) {
-            printf("3");
           /* Remove extra bytes from old string */
-          rb_str_update(param_buffer, upper_bound + 1, old_upper_bound + 1, rb_str_new2(""));
+          rb_str_update(param_buffer, upper_bound + 1, old_upper_bound - upper_bound, rb_str_new2(""));
         } else if ((upper_bound > old_upper_bound) && (end_bytes > 0)) {
-            printf("4 bytes:%d\n",end_bytes);
           /* Preserve bytes at end of buffer */
           rb_str_concat(param_buffer, rb_str_times(ZERO_STRING, INT2FIX(upper_bound - old_upper_bound)));
           buffer = (unsigned char*) RSTRING_PTR(param_buffer);

--- a/ext/cosmos/ext/structure/structure.c
+++ b/ext/cosmos/ext/structure/structure.c
@@ -875,7 +875,8 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
     bit_size = RSTRING_LEN(value) * 8;
   }
 
-  if ((!check_bounds_and_buffer_size(bit_offset, bit_size, buffer_length, param_endianness, param_data_type, &lower_bound, &upper_bound)) && (given_bit_size > 0)) {
+  if ((!check_bounds_and_buffer_size(bit_offset, bit_size, buffer_length, param_endianness, param_data_type, &lower_bound, &upper_bound)) && (given_bit_size > 0))
+  {
     rb_funcall(self, id_method_raise_buffer_error, 5, symbol_write, param_buffer, param_data_type, param_bit_offset, param_bit_size);
   }
 
@@ -902,10 +903,9 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
       if (given_bit_size <= 0) {
         end_bytes = -(given_bit_size / 8);
         old_upper_bound = buffer_length - 1 - end_bytes;
-        /* If the buffer is not already big enough to hold the non-variable sized items
-             that is a buffer error.  old_upper_bound can be -1 if the string is exactly the size of the
-             end_bytes which is ok */
-        if (old_upper_bound < -1) {
+        /* Lower bound + end_bytes can never be more than 1 byte outside of the given buffer */
+        if ((lower_bound + end_bytes) > buffer_length)
+        {
           rb_funcall(self, id_method_raise_buffer_error, 5, symbol_write, param_buffer, param_data_type, param_bit_offset, param_bit_size);
         }
 

--- a/spec/packets/binary_accessor_spec.rb
+++ b/spec/packets/binary_accessor_spec.rb
@@ -797,6 +797,24 @@ module Cosmos
           expect { BinaryAccessor.write(data, 0, -16, :BLOCK, buffer, :BIG_ENDIAN, :ERROR) }.to raise_error(ArgumentError, "0 byte buffer insufficient to write BLOCK at bit_offset 0 with bit_size -16")
         end
 
+        it "handles a huge bit offset with small buffer" do
+          data = ''
+          512.times do |index|
+            data << [index].pack("n")
+          end
+          buffer = ""
+          expect { BinaryAccessor.write(data, 1024, 0, :BLOCK, buffer, :BIG_ENDIAN, :ERROR) }.to raise_error(ArgumentError, "0 byte buffer insufficient to write BLOCK at bit_offset 1024 with bit_size 0")
+        end
+
+        it "handles an edge case bit offset" do
+          data = ''
+          512.times do |index|
+            data << [index].pack("n")
+          end
+          buffer = "\x00" * 127
+          expect { BinaryAccessor.write(data, 1024, 0, :BLOCK, buffer, :BIG_ENDIAN, :ERROR) }.to raise_error(ArgumentError, "127 byte buffer insufficient to write BLOCK at bit_offset 1024 with bit_size 0")
+        end
+
         it "writes a block to a small buffer preserving the end" do
           data = ''
           512.times do |index|


### PR DESCRIPTION
I checked out the old binary_accessor write code to see how it handled the new specs. One failure:
```
rspec ./spec/packets/binary_accessor_spec.rb:791 # Cosmos::BinaryAccessor write only when
negative bit size writes a block to an empty buffer
```
I think the new behavior is correct. I expected to see a failure for 832: writes a block to a large buffer since I didn't think we were handling that in the old code. Old Ruby code:
```
# Preserve bytes at end of buffer
buffer_length = buffer.length
diff = upper_bound - old_upper_bound
buffer << ZERO_STRING * diff
buffer[(upper_bound + 1)..(buffer.length - 1)] = buffer[(old_upper_bound + 1)..(buffer_length - 1)]
```
The old_upper_bound is a large negative number in my new spec so we append a large amount of data to the buffer. We then promptly throw it away in the next line. The new C code checks to see if the end_bytes are bigger than the buffer (they passed in a large negative bit size) and then sets it to the buffer length.