### PR TITLE
Change the launcher behavior for the CmdTlmServer

### DIFF
--- a/lib/cosmos/tools/launcher/launcher_tool.rb
+++ b/lib/cosmos/tools/launcher/launcher_tool.rb
@@ -12,7 +12,6 @@ require 'cosmos'
 require 'cosmos/gui/qt'
 
 module Cosmos
-
   class LauncherTool < Qt::Object
     slots 'button_clicked()'
 
@@ -26,7 +25,7 @@ module Cosmos
 
     def button_clicked
       if @variable_parameters
-        parameters = parameters_dialog()
+        parameters = parameters_dialog
         if parameters
           if @capture_io
             Cosmos.run_process_check_output(@shell_command + ' ' + parameters)
@@ -44,7 +43,7 @@ module Cosmos
     end
 
     def parameters_dialog
-      dialog = Qt::Dialog.new(self.parent)
+      dialog = Qt::Dialog.new(parent)
       dialog.window_title = "#{@button_text} Options"
       layout = Qt::VBoxLayout.new
       dialog.layout = layout
@@ -54,22 +53,19 @@ module Cosmos
         hlayout = Qt::HBoxLayout.new
         hlayout.addWidget(Qt::Label.new(parameter_name))
         parameter_options = parameter_value.split('|')
-        if parameter_options.length()>1
-          combo_box = Qt::ComboBox.new()
+        if parameter_options.length > 1
+          combo_box = Qt::ComboBox.new
           combo_box.setEditable(true)
-          idx=0
-          default_option=parameter_options[0]
-          parameter_options.sort().each {|option|
-            combo_box.insertItem(idx,option)
-            if option.eql?(default_option)
-              combo_box.setCurrentIndex(idx)
-            end
-            idx+=1
-          }
+          idx = 0
+          parameter_options.each do |option|
+            combo_box.insertItem(idx, option)
+            idx += 1
+          end
+          combo_box.setCurrentIndex(0) # Default Option is the first one
           hlayout.addWidget(combo_box)
           widgets << combo_box
         else
-          line_edit = Qt::LineEdit.new()
+          line_edit = Qt::LineEdit.new
           line_edit.setText(parameter_value)
           hlayout.addWidget(line_edit)
           widgets << line_edit
@@ -102,7 +98,7 @@ module Cosmos
       if result == Qt::Dialog::Accepted
         parameters = ''
         index = 0
-        @variable_parameters.each do |parameter_name, parameter_value|
+        @variable_parameters.each do |parameter_name, _parameter_value|
           parameters << parameter_name
           parameters << ' '
           parameters << widgets[index].text

--- a/lib/cosmos/tools/launcher/launcher_tool.rb
+++ b/lib/cosmos/tools/launcher/launcher_tool.rb
@@ -53,24 +53,19 @@ module Cosmos
       @variable_parameters.each do |parameter_name, parameter_value|
         hlayout = Qt::HBoxLayout.new
         hlayout.addWidget(Qt::Label.new(parameter_name))
-        if @shell_command.match(".*/CmdTlmServer") and parameter_name.match("config")
+        parameter_options = parameter_value.split('|')
+        if parameter_options.length()>1
           combo_box = Qt::ComboBox.new()
-          if Dir.exists?('config/tools/cmd_tlm_server')
-            Dir.chdir('config/tools/cmd_tlm_server')
-            idx=0
-            default_idx=0
-            Dir.glob('*.txt').sort().each {|config|
-              combo_box.insertItem(idx,config)
-              if config.eql?(parameter_value)
-                default_idx = idx
-              end
-              idx+=1
-            }
-          else
-            combo_box.insertItem(0,parameter_value)
-          end
-          combo_box.setCurrentIndex(default_idx)
           combo_box.setEditable(true)
+          idx=0
+          default_option=parameter_options[0]
+          parameter_options.sort().each {|option|
+            combo_box.insertItem(idx,option)
+            if option.eql?(default_option)
+              combo_box.setCurrentIndex(idx)
+            end
+            idx+=1
+          }
           hlayout.addWidget(combo_box)
           widgets << combo_box
         else

--- a/lib/cosmos/tools/launcher/launcher_tool.rb
+++ b/lib/cosmos/tools/launcher/launcher_tool.rb
@@ -53,10 +53,32 @@ module Cosmos
       @variable_parameters.each do |parameter_name, parameter_value|
         hlayout = Qt::HBoxLayout.new
         hlayout.addWidget(Qt::Label.new(parameter_name))
-        line_edit = Qt::LineEdit.new()
-        line_edit.setText(parameter_value)
-        hlayout.addWidget(line_edit)
-        widgets << line_edit
+        if @shell_command.match(".*/CmdTlmServer") and parameter_name.match("config")
+          combo_box = Qt::ComboBox.new()
+          if Dir.exists?('config/tools/cmd_tlm_server')
+            Dir.chdir('config/tools/cmd_tlm_server')
+            idx=0
+            default_idx=0
+            Dir.glob('*.txt').sort().each {|config|
+              combo_box.insertItem(idx,config)
+              if config.eql?(parameter_value)
+                default_idx = idx
+              end
+              idx+=1
+            }
+          else
+            combo_box.insertItem(0,parameter_value)
+          end
+          combo_box.setCurrentIndex(default_idx)
+          combo_box.setEditable(true)
+          hlayout.addWidget(combo_box)
+          widgets << combo_box
+        else
+          line_edit = Qt::LineEdit.new()
+          line_edit.setText(parameter_value)
+          hlayout.addWidget(line_edit)
+          widgets << line_edit
+        end
         layout.addLayout(hlayout)
       end
 
@@ -100,5 +122,4 @@ module Cosmos
       end
     end
   end
-
 end


### PR DESCRIPTION
Replace the LineEdit widget with a ComboBox when launching CmdTlmServer. Making it easier to select alternate valid configurations.