### PR TITLE
Added CanvasdotWidget.

### DIFF
--- a/lib/cosmos/tools/tlm_viewer/widgets.rb
+++ b/lib/cosmos/tools/tlm_viewer/widgets.rb
@@ -1,8 +1,8 @@
 # encoding: ascii-8bit
-
 require 'cosmos/tools/tlm_viewer/widgets/array_widget.rb'
 require 'cosmos/tools/tlm_viewer/widgets/block_widget.rb'
 require 'cosmos/tools/tlm_viewer/widgets/button_widget.rb'
+require 'cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb'
 require 'cosmos/tools/tlm_viewer/widgets/canvasimagevalue_widget.rb'
 require 'cosmos/tools/tlm_viewer/widgets/canvasimage_widget.rb'
 require 'cosmos/tools/tlm_viewer/widgets/canvaslabelvalue_widget.rb'

--- a/lib/cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb
+++ b/lib/cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb
@@ -14,66 +14,66 @@ module Cosmos
 
   class CanvasdotWidget
     include Widget
-
+    
     def initialize(parent_layout, x, y, color='black', width=3)
       super()
       if is_numeric?(x)
         @x = x.to_i
       else
-	      @x = x.to_s
-	    end
-	  
-  	  if is_numeric?(y)
+        @x = x.to_s
+      end
+    
+      if is_numeric?(y)
         @y = y.to_i
-  	  else
-  	    @y = y.to_s
-  	  end
-	  
+      else
+        @y = y.to_s
+      end
+    
       @point = Qt::Point.new(0, 0)
-  	  update_point
-	  
+      update_point
+    
       @width = width.to_i
       @color = Cosmos::getColor(color)
       parent_layout.add_repaint(self)
-    end
-  	
+    end # initialize
+    
     def update_point
       if is_numeric?(@x)
-  	    @point.x = @x
-  	  else
-  	    @point.x = eval_str(@x)
-  	  end
-  	  
-  	  if is_numeric?(@y)
-  	    @point.y = @y
-  	  else
-  	    @point.y = eval_str(@y)
-  	  end
-	  end
-	
-  	def is_numeric?(obj) 
+        @point.x = @x
+      else
+        @point.x = eval_str(@x)
+      end
+      
+      if is_numeric?(@y)
+        @point.y = @y
+      else
+        @point.y = eval_str(@y)
+      end
+    end # update_point
+  
+    def is_numeric?(obj) 
       obj.to_s.match(/\A[+-]?\d+?(\.\d+)?\Z/) == nil ? false : true
     end
-  
+
     def paint(painter)
       painter.save
       painter.setBrush(@color)
       painter.drawEllipse(@point, @width, @width)
       painter.restore
     end
-  	
-  	def eval_str(string_to_eval)
+  
+    def eval_str(string_to_eval)
       @screen.instance_eval(string_to_eval)
     end
-  	
-  	def update_widget
+  
+    def update_widget
       update_point
     end
-  
+
     def dispose
       super()
       @point.dispose
     end
-  end
+  end # CanvasdotWidget
 
 end # module Cosmos

--- a/lib/cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb
+++ b/lib/cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb
@@ -20,56 +20,56 @@ module Cosmos
       if is_numeric?(x)
         @x = x.to_i
       else
-	    @x = x.to_s
-	  end
+	      @x = x.to_s
+	    end
 	  
-	  if is_numeric?(y)
+  	  if is_numeric?(y)
         @y = y.to_i
-	  else
-	    @y = y.to_s
-	  end
+  	  else
+  	    @y = y.to_s
+  	  end
 	  
       @point = Qt::Point.new(0, 0)
-	  update_point
+  	  update_point
 	  
       @width = width.to_i
       @color = Cosmos::getColor(color)
       parent_layout.add_repaint(self)
     end
-	
-	def update_point
+  	
+    def update_point
       if is_numeric?(@x)
-	    @point.x = @x
-	  else
-	    @point.x = eval_str(@x)
+  	    @point.x = @x
+  	  else
+  	    @point.x = eval_str(@x)
+  	  end
+  	  
+  	  if is_numeric?(@y)
+  	    @point.y = @y
+  	  else
+  	    @point.y = eval_str(@y)
+  	  end
 	  end
-	  
-	  if is_numeric?(@y)
-	    @point.y = @y
-	  else
-	    @point.y = eval_str(@y)
-	  end
-	end
 	
-	def is_numeric?(obj) 
+  	def is_numeric?(obj) 
       obj.to_s.match(/\A[+-]?\d+?(\.\d+)?\Z/) == nil ? false : true
     end
-
+  
     def paint(painter)
       painter.save
       painter.setBrush(@color)
       painter.drawEllipse(@point, @width, @width)
       painter.restore
     end
-	
-	def eval_str(string_to_eval)
+  	
+  	def eval_str(string_to_eval)
       @screen.instance_eval(string_to_eval)
     end
-	
-	def update_widget
+  	
+  	def update_widget
       update_point
     end
-
+  
     def dispose
       super()
       @point.dispose

--- a/lib/cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb
+++ b/lib/cosmos/tools/tlm_viewer/widgets/canvasdot_widget.rb
@@ -1,0 +1,79 @@
+# encoding: ascii-8bit
+
+# Copyright 2014 Ball Aerospace & Technologies Corp.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+
+require 'cosmos/tools/tlm_viewer/widgets/widget'
+
+module Cosmos
+
+  class CanvasdotWidget
+    include Widget
+
+    def initialize(parent_layout, x, y, color='black', width=3)
+      super()
+      if is_numeric?(x)
+        @x = x.to_i
+      else
+	    @x = x.to_s
+	  end
+	  
+	  if is_numeric?(y)
+        @y = y.to_i
+	  else
+	    @y = y.to_s
+	  end
+	  
+      @point = Qt::Point.new(0, 0)
+	  update_point
+	  
+      @width = width.to_i
+      @color = Cosmos::getColor(color)
+      parent_layout.add_repaint(self)
+    end
+	
+	def update_point
+      if is_numeric?(@x)
+	    @point.x = @x
+	  else
+	    @point.x = eval_str(@x)
+	  end
+	  
+	  if is_numeric?(@y)
+	    @point.y = @y
+	  else
+	    @point.y = eval_str(@y)
+	  end
+	end
+	
+	def is_numeric?(obj) 
+      obj.to_s.match(/\A[+-]?\d+?(\.\d+)?\Z/) == nil ? false : true
+    end
+
+    def paint(painter)
+      painter.save
+      painter.setBrush(@color)
+      painter.drawEllipse(@point, @width, @width)
+      painter.restore
+    end
+	
+	def eval_str(string_to_eval)
+      @screen.instance_eval(string_to_eval)
+    end
+	
+	def update_widget
+      update_point
+    end
+
+    def dispose
+      super()
+      @point.dispose
+    end
+  end
+
+end # module Cosmos


### PR DESCRIPTION
The CANVASDOT widget draws a dot onto the canvas.
This new widget is very useful as it can be programmed to change its position with ruby code.

Parameter | Description | Required
------------- | --------------- | -------------
x __or__ str to eval | X position of the dot, or it can be a string of ruby code | Yes
y __or__ str to eval | Y position of the dot, or it can be a string of ruby code | Yes
color | Color of the dot (default = black) | No
width | Width of the dot in pixels (default = 3) | No

Here is an example of a red CanvasDot showing the position of a gimbal from home.
![720311333_78794](https://cloud.githubusercontent.com/assets/5217851/11122513/d29af8c0-8918-11e5-9138-17011956911a.jpg)
