### PR TITLE
Add command line option to set polling rate for Packet Viewer.

### DIFF
--- a/data/crc.txt
+++ b/data/crc.txt
@@ -127,7 +127,7 @@
 "lib/cosmos/tools/cmd_tlm_server/interface_thread.rb" 0x7215DAF9
 "lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server_gui.rb" 0x50E37D3B
 "lib/cosmos/tools/limits_monitor/limits_monitor.rb" 0x0321B411
-"lib/cosmos/tools/packet_viewer/packet_viewer.rb" 0x859EC490
+"lib/cosmos/tools/packet_viewer/packet_viewer.rb" 0x96CF2D3A
 "lib/cosmos/tools/table_manager/table_manager.rb" 0x05E19031
 "lib/cosmos/tools/table_manager/table.rb" 0x923A8589
 "lib/cosmos/tools/table_manager/table_item.rb" 0x08A9A262

--- a/data/crc.txt
+++ b/data/crc.txt
@@ -127,7 +127,7 @@
 "lib/cosmos/tools/cmd_tlm_server/interface_thread.rb" 0x7215DAF9
 "lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server_gui.rb" 0x50E37D3B
 "lib/cosmos/tools/limits_monitor/limits_monitor.rb" 0x0321B411
-"lib/cosmos/tools/packet_viewer/packet_viewer.rb" 0x96CF2D3A
+"lib/cosmos/tools/packet_viewer/packet_viewer.rb" 0x2188531F
 "lib/cosmos/tools/table_manager/table_manager.rb" 0x05E19031
 "lib/cosmos/tools/table_manager/table.rb" 0x923A8589
 "lib/cosmos/tools/table_manager/table_item.rb" 0x08A9A262

--- a/lib/cosmos/tools/packet_viewer/packet_viewer.rb
+++ b/lib/cosmos/tools/packet_viewer/packet_viewer.rb
@@ -535,7 +535,7 @@ module Cosmos
             end
             options.packet = split
           end
-          option_parser.on("-r", "--rate PERIOD", "Set the polling rate to PERIOD (unit seconds)") { |arg| options.rate = arg.to_f } 
+          option_parser.on("-r", "--rate PERIOD", "Set the polling rate to PERIOD (unit seconds)") { |arg| options.rate = Float(arg) } 
         end
 
         super(option_parser, options)

--- a/lib/cosmos/tools/packet_viewer/packet_viewer.rb
+++ b/lib/cosmos/tools/packet_viewer/packet_viewer.rb
@@ -35,7 +35,11 @@ module Cosmos
       @tlm_thread = nil
       @shutdown_tlm_thread = false
       @mode = :WITH_UNITS
-      @polling_rate = 1.0
+      if options.rate
+        @polling_rate = options.rate
+      else
+        @polling_rate = 1.0
+      end
       @colorblind = false
 
       initialize_actions()
@@ -249,7 +253,7 @@ module Cosmos
     end
 
     def file_options
-      @polling_rate = Qt::InputDialog.getDouble(self, tr("Options"), tr("Polling Rate:"), @polling_rate, 0, 1000, 1, nil)
+      @polling_rate = Qt::InputDialog.getDouble(self, tr("Options"), tr("Polling Rate (sec):"), @polling_rate, 0, 1000, 1, nil)
     end
 
     def update_all
@@ -531,6 +535,7 @@ module Cosmos
             end
             options.packet = split
           end
+          option_parser.on("-r", "--rate PERIOD", "Set the polling rate to PERIOD (unit seconds)") { |arg| options.rate = arg.to_f } 
         end
 
         super(option_parser, options)


### PR DESCRIPTION
Feature to set the polling rate in Packet Viewer from the command line. Useful for a default multi tool launch when want to view updates faster than 1 Hz.