### PR TITLE
Ruby 2.4.0 Integer Unification Fix

### DIFF
--- a/ext/cosmos/ext/packet/packet.c
+++ b/ext/cosmos/ext/packet/packet.c
@@ -191,9 +191,15 @@ static VALUE received_time_equals(VALUE self, VALUE received_time) {
  *   received */
 static VALUE received_count_equals(VALUE self, VALUE received_count) {
   volatile VALUE read_conversion_cache = rb_ivar_get(self, id_ivar_read_conversion_cache);
+#ifdef RUBY_INTEGER_UNIFICATION /* Ruby 2.4.0 unified Fixnum and Bignum into Integer. This check allows the code to build pre- and post-2.4.0. */
+  if (rb_funcall(received_count, id_method_class, 0) != rb_cInteger) {
+      rb_raise(rb_eArgError, "received_count must be an Integer but is a %s", RSTRING_PTR(rb_funcall(rb_funcall(received_count, id_method_class, 0), id_method_to_s, 0)));
+  }
+#else
   if (rb_funcall(received_count, id_method_class, 0) != rb_cFixnum) {
     rb_raise(rb_eArgError, "received_count must be a Fixnum but is a %s", RSTRING_PTR(rb_funcall(rb_funcall(received_count, id_method_class, 0), id_method_to_s, 0)));
   }
+#endif
   rb_ivar_set(self, id_ivar_received_count, received_count);
   if (RTEST(read_conversion_cache)) {
     rb_funcall(read_conversion_cache, id_method_clear, 0);

--- a/lib/cosmos/packets/packet_item_limits.rb
+++ b/lib/cosmos/packets/packet_item_limits.rb
@@ -91,12 +91,24 @@ module Cosmos
     end
 
     def persistence_setting=(persistence_setting)
-      raise ArgumentError, "persistence_setting must be a Fixnum but is a #{persistence_setting.class}" unless Fixnum === persistence_setting
+      if 0.class == Integer
+        # Ruby version >= 2.4.0
+        raise ArgumentError, "persistence_setting must be an Integer but is a #{persistence_setting.class}" unless Integer === persistence_setting
+      else
+        # Ruby version < 2.4.0
+        raise ArgumentError, "persistence_setting must be a Fixnum but is a #{persistence_setting.class}" unless Fixnum === persistence_setting
+      end
       @persistence_setting = persistence_setting
     end
 
     def persistence_count=(persistence_count)
-      raise ArgumentError, "persistence_count must be a Fixnum but is a #{persistence_count.class}" unless Fixnum === persistence_count
+      if 0.class == Integer
+        # Ruby version >= 2.4.0
+        raise ArgumentError, "persistence_count must be an Integer but is a #{persistence_count.class}" unless Integer === persistence_count
+      else
+        # Ruby version < 2.4.0
+        raise ArgumentError, "persistence_count must be a Fixnum but is a #{persistence_count.class}" unless Fixnum === persistence_count
+      end
       @persistence_count = persistence_count
     end
 

--- a/lib/cosmos/packets/structure_item.rb
+++ b/lib/cosmos/packets/structure_item.rb
@@ -104,7 +104,14 @@ module Cosmos
     end
 
     def bit_offset=(bit_offset)
-      raise ArgumentError, "#{@name}: bit_offset must be a Fixnum" unless Fixnum === bit_offset
+      if 0.class == Integer
+        # Ruby version >= 2.4.0
+        raise ArgumentError, "#{@name}: bit_offset must be an Integer" unless Integer === bit_offset
+      else
+        # Ruby version < 2.4.0
+        raise ArgumentError, "#{@name}: bit_offset must be a Fixnum" unless Fixnum === bit_offset
+      end
+
       byte_aligned = ((bit_offset % 8) == 0)
       if (@data_type == :FLOAT or @data_type == :STRING or @data_type == :BLOCK) and !byte_aligned
         raise ArgumentError, "#{@name}: bit_offset for :FLOAT, :STRING, and :BLOCK items must be byte aligned"
@@ -118,7 +125,13 @@ module Cosmos
     end
 
     def bit_size=(bit_size)
-      raise ArgumentError, "#{name}: bit_size must be a Fixnum" unless Fixnum === bit_size
+      if 0.class == Integer
+        # Ruby version >=  2.4.0
+        raise ArgumentError, "#{name}: bit_size must be an Integer" unless Integer === bit_size
+      else
+        # Ruby version < 2.4.0
+        raise ArgumentError, "#{name}: bit_size must be a Fixnum" unless Fixnum === bit_size
+      end
       byte_multiple = ((bit_size % 8) == 0)
       if bit_size <= 0 and (@data_type == :INT or @data_type == :UINT or @data_type == :FLOAT)
         raise ArgumentError, "#{@name}: bit_size cannot be negative or zero for :INT, :UINT, and :FLOAT items: #{bit_size}"
@@ -150,7 +163,13 @@ module Cosmos
 
     def array_size=(array_size)
       if array_size
-        raise ArgumentError, "#{@name}: array_size must be a Fixnum" unless Fixnum === array_size
+        if 0.class == Integer
+          # Ruby version >=  2.4.0
+          raise ArgumentError, "#{@name}: array_size must be an Integer" unless Integer === array_size
+        else
+          # Ruby version < 2.4.0
+          raise ArgumentError, "#{@name}: array_size must be a Fixnum" unless Fixnum === array_size
+        end
         raise ArgumentError, "#{@name}: array_size must be a multiple of bit_size" unless (@bit_size == 0 or (array_size % @bit_size == 0) or array_size < 0)
         raise ArgumentError, "#{@name}: bit_size cannot be negative or zero for array items" if @bit_size <= 0
       end

--- a/spec/packets/packet_item_limits_spec.rb
+++ b/spec/packets/packet_item_limits_spec.rb
@@ -84,11 +84,25 @@ module Cosmos
       end
 
       it "complains about persistence_setting = nil" do
-        expect { @l.persistence_setting = nil}.to raise_error(ArgumentError, "persistence_setting must be a Fixnum but is a NilClass")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect { @l.persistence_setting = nil}.to raise_error(ArgumentError, "persistence_setting must be an Integer but is a NilClass")
+        else
+          # Ruby version < 2.4.0
+          expect { @l.persistence_setting = nil}.to raise_error(ArgumentError, "persistence_setting must be a Fixnum but is a NilClass")
+        end
       end
 
-      it "complains about persistence_setting that aren't Fixnum" do
-        expect { @l.persistence_setting = 5.5}.to raise_error(ArgumentError, "persistence_setting must be a Fixnum but is a Float")
+      if 0.class == Integer
+      # Ruby version >= 2.4.0
+        it "complains about persistence_setting that aren't Integer" do
+          expect { @l.persistence_setting = 5.5}.to raise_error(ArgumentError, "persistence_setting must be an Integer but is a Float")
+        end
+      else
+        # Ruby version < 2.4.0
+        it "complains about persistence_setting that aren't Fixnum" do
+          expect { @l.persistence_setting = 5.5}.to raise_error(ArgumentError, "persistence_setting must be a Fixnum but is a Float")
+        end
       end
     end
 
@@ -100,11 +114,24 @@ module Cosmos
       end
 
       it "complains about persistence_count = nil" do
-        expect { @l.persistence_count = nil}.to raise_error(ArgumentError, "persistence_count must be a Fixnum but is a NilClass")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect { @l.persistence_count = nil}.to raise_error(ArgumentError, "persistence_count must be an Integer but is a NilClass")
+        else
+          # Ruby version < 2.4.0
+          expect { @l.persistence_count = nil}.to raise_error(ArgumentError, "persistence_count must be a Fixnum but is a NilClass")
+        end
       end
 
-      it "complains about persistence_count that aren't Fixnum" do
-        expect { @l.persistence_count = 5.5}.to raise_error(ArgumentError, "persistence_count must be a Fixnum but is a Float")
+      if 0.class == Integer
+        it "complains about persistence_count that aren't Integer" do
+          expect { @l.persistence_count = 5.5}.to raise_error(ArgumentError, "persistence_count must be an Integer but is a Float")
+        end
+      else
+        # Ruby version < 2.4.0
+        it "complains about persistence_count that aren't Fixnum" do
+          expect { @l.persistence_count = 5.5}.to raise_error(ArgumentError, "persistence_count must be a Fixnum but is a Float")
+        end
       end
     end
 

--- a/spec/packets/packet_item_spec.rb
+++ b/spec/packets/packet_item_spec.rb
@@ -32,7 +32,7 @@ module Cosmos
       end
 
       it "complains about non String format_strings" do
-        expect { @pi.format_string = 5 }.to raise_error(ArgumentError, "#{@pi.name}: format_string must be a String but is a Fixnum")
+        expect { @pi.format_string = 5.1 }.to raise_error(ArgumentError, "#{@pi.name}: format_string must be a String but is a Float")
       end
 
       it "complains about badly formatted format_strings" do
@@ -130,7 +130,7 @@ module Cosmos
       end
 
       it "complains about description that aren't Strings" do
-        expect { @pi.description = 5}.to raise_error(ArgumentError, "#{@pi.name}: description must be a String but is a Fixnum")
+        expect { @pi.description = 5.1}.to raise_error(ArgumentError, "#{@pi.name}: description must be a String but is a Float")
       end
     end
 
@@ -147,7 +147,7 @@ module Cosmos
       end
 
       it "complains about units_full that aren't Strings" do
-        expect { @pi.units_full = 5}.to raise_error(ArgumentError, "#{@pi.name}: units_full must be a String but is a Fixnum")
+        expect { @pi.units_full = 5.1}.to raise_error(ArgumentError, "#{@pi.name}: units_full must be a String but is a Float")
       end
     end
 
@@ -164,7 +164,7 @@ module Cosmos
       end
 
       it "complains about units that aren't Strings" do
-        expect { @pi.units = 5}.to raise_error(ArgumentError, "#{@pi.name}: units must be a String but is a Fixnum")
+        expect { @pi.units = 5.1}.to raise_error(ArgumentError, "#{@pi.name}: units must be a String but is a Float")
       end
     end
 
@@ -193,8 +193,8 @@ module Cosmos
     describe "check_default_and_range_data_types" do
       it "complains about default not matching data_type" do
         pi = PacketItem.new("test", 0, 8, :UINT, :BIG_ENDIAN, 16)
-        pi.default = 1
-        expect { pi.check_default_and_range_data_types }.to raise_error(ArgumentError, "TEST: default must be an Array but is a Fixnum")
+        pi.default = 1.1
+        expect { pi.check_default_and_range_data_types }.to raise_error(ArgumentError, "TEST: default must be an Array but is a Float")
         pi = PacketItem.new("test", 0, 8, :UINT, :BIG_ENDIAN, 16)
         pi.default = []
         expect { pi.check_default_and_range_data_types }.to_not raise_error
@@ -214,8 +214,8 @@ module Cosmos
         pi.default = 5.5
         expect { pi.check_default_and_range_data_types  }.to_not raise_error
         pi = PacketItem.new("test", 0, 32, :STRING, :BIG_ENDIAN, nil)
-        pi.default = 5
-        expect { pi.check_default_and_range_data_types }.to raise_error(ArgumentError, "TEST: default must be a String but is a Fixnum")
+        pi.default = 5.1
+        expect { pi.check_default_and_range_data_types }.to raise_error(ArgumentError, "TEST: default must be a String but is a Float")
         pi = PacketItem.new("test", 0, 32, :STRING, :BIG_ENDIAN, nil)
         pi.default = ''
         expect { pi.check_default_and_range_data_types }.to_not raise_error
@@ -258,7 +258,7 @@ module Cosmos
       end
 
       it "complains about ranges that aren't Ranges" do
-        expect { @pi.range = 5}.to raise_error(ArgumentError, "#{@pi.name}: range must be a Range but is a Fixnum")
+        expect { @pi.range = 5.1}.to raise_error(ArgumentError, "#{@pi.name}: range must be a Range but is a Float")
       end
     end
 

--- a/spec/packets/packet_spec.rb
+++ b/spec/packets/packet_spec.rb
@@ -53,7 +53,7 @@ module Cosmos
       end
 
       it "complains about non String target_names" do
-        expect { Packet.new(5, "pkt") }.to raise_error(ArgumentError, "target_name must be a String but is a Fixnum")
+        expect { Packet.new(5.1, "pkt") }.to raise_error(ArgumentError, "target_name must be a String but is a Float")
       end
     end
 
@@ -69,7 +69,7 @@ module Cosmos
       end
 
       it "complains about non String packet_names" do
-        expect { Packet.new("tgt", 5) }.to raise_error(ArgumentError, "packet_name must be a String but is a Fixnum")
+        expect { Packet.new("tgt", 5.1) }.to raise_error(ArgumentError, "packet_name must be a String but is a Float")
       end
     end
 
@@ -87,7 +87,7 @@ module Cosmos
 
       it "complains about non String descriptions" do
         p = Packet.new("tgt","pkt")
-        expect { p.description = 5 }.to raise_error(ArgumentError, "description must be a String but is a Fixnum")
+        expect { p.description = 5.1 }.to raise_error(ArgumentError, "description must be a String but is a Float")
       end
     end
 
@@ -140,12 +140,24 @@ module Cosmos
 
       it "complains about nil received_count" do
         p = Packet.new("tgt","pkt")
-        expect {p.received_count = nil }.to raise_error(ArgumentError, "received_count must be a Fixnum but is a NilClass")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect {p.received_count = nil }.to raise_error(ArgumentError, "received_count must be an Integer but is a NilClass")
+        else
+          # Ruby version < 2.4.0
+          expect {p.received_count = nil }.to raise_error(ArgumentError, "received_count must be a Fixnum but is a NilClass")
+        end
       end
 
       it "complains about non Fixnum received_counts" do
         p = Packet.new("tgt","pkt")
-        expect {p.received_count = "5" }.to raise_error(ArgumentError, "received_count must be a Fixnum but is a String")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect {p.received_count = "5" }.to raise_error(ArgumentError, "received_count must be an Integer but is a String")
+        else
+          # Ruby version < 2.4.0
+          expect {p.received_count = "5" }.to raise_error(ArgumentError, "received_count must be a Fixnum but is a String")
+        end
       end
     end
 
@@ -164,7 +176,7 @@ module Cosmos
 
       it "complains about non String hazardous_descriptions" do
         p = Packet.new("tgt","pkt")
-        expect {p.hazardous_description = 5 }.to raise_error(ArgumentError, "hazardous_description must be a String but is a Fixnum")
+        expect {p.hazardous_description = 5.1 }.to raise_error(ArgumentError, "hazardous_description must be a String but is a Float")
       end
     end
 

--- a/spec/packets/structure_item_spec.rb
+++ b/spec/packets/structure_item_spec.rb
@@ -23,7 +23,7 @@ module Cosmos
 
       it "complains about non String names" do
         expect { StructureItem.new(nil, 0, 8, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "name must be a String but is a NilClass")
-        expect { StructureItem.new(5, 0, 8, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "name must be a String but is a Fixnum")
+        expect { StructureItem.new(5.1, 0, 8, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "name must be a String but is a Float")
       end
 
       it "complains about blank names" do
@@ -69,7 +69,13 @@ module Cosmos
 
     describe "bit_offset=" do
       it "compains about bad bit offsets types" do
-        expect { StructureItem.new("test", nil, 8, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "TEST: bit_offset must be a Fixnum")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect { StructureItem.new("test", nil, 8, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "TEST: bit_offset must be an Integer")
+        else
+          # Ruby version < 2.4.0
+          expect { StructureItem.new("test", nil, 8, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "TEST: bit_offset must be a Fixnum")
+        end
       end
 
       it "complains about unaligned bit offsets" do
@@ -85,7 +91,13 @@ module Cosmos
 
     describe "bit_size=" do
       it "complains about bad bit sizes types" do
-        expect { StructureItem.new("test", 0, nil, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "TEST: bit_size must be a Fixnum")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect { StructureItem.new("test", 0, nil, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "TEST: bit_size must be an Integer")
+          else
+          # Ruby version < 2.4.0
+          expect { StructureItem.new("test", 0, nil, :UINT, :BIG_ENDIAN, nil) }.to raise_error(ArgumentError, "TEST: bit_size must be a Fixnum")
+        end
       end
 
       it "complains about 0 size INT, UINT, and FLOAT" do
@@ -110,7 +122,13 @@ module Cosmos
 
     describe "array_size=" do
       it "complains about bad array size types" do
-        expect { StructureItem.new("test", 0, 8, :UINT, :BIG_ENDIAN, "") }.to raise_error(ArgumentError, "TEST: array_size must be a Fixnum")
+        if 0.class == Integer
+          # Ruby version >= 2.4.0
+          expect { StructureItem.new("test", 0, 8, :UINT, :BIG_ENDIAN, "") }.to raise_error(ArgumentError, "TEST: array_size must be an Integer")
+        else
+          # Ruby version < 2.4.0
+          expect { StructureItem.new("test", 0, 8, :UINT, :BIG_ENDIAN, "") }.to raise_error(ArgumentError, "TEST: array_size must be a Fixnum")
+        end
       end
 
       it "complains about array size != multiple of bit size" do

--- a/spec/tools/table_manager/table_item_spec.rb
+++ b/spec/tools/table_manager/table_item_spec.rb
@@ -28,7 +28,7 @@ module Cosmos
       end
 
       it "complains about non boolean values" do
-        expect { @ti.editable = 5 }.to raise_error(ArgumentError, "#{@ti.name}: editable must be a boolean but is a Fixnum")
+        expect { @ti.editable = 5.1 }.to raise_error(ArgumentError, "#{@ti.name}: editable must be a boolean but is a Float")
       end
     end
 


### PR DESCRIPTION
Ruby 2.4.0 unified Fixnum and Bignum into Integer. Fixnum is used in packet code and as a result COSMOS does not build when using Ruby versions >= 2.4.0.

See:
https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/
https://github.com/ruby/ruby/blob/v2_4_0/NEWS

This commit addresses the change and allows COSMOS to build and run for both pre- and post-2.4.0 versions of Ruby.