### PR TITLE
re #233 Add CTS timeout configuration option to TlmGrapher

### DIFF
--- a/lib/cosmos/tools/tlm_grapher/tabbed_plots_tool/tabbed_plots_config.rb
+++ b/lib/cosmos/tools/tlm_grapher/tabbed_plots_tool/tabbed_plots_config.rb
@@ -32,6 +32,7 @@ module Cosmos
     DEFAULT_POINTS_SAVED = 1000000
     DEFAULT_POINTS_PLOTTED = 1000
     DEFAULT_REFRESH_RATE_HZ = 10.0
+    DEFAULT_CTS_TIMEOUT = 10.0
 
     # Gives access to the array of tabs defined by the configuration file
     attr_accessor :tabs
@@ -47,6 +48,9 @@ module Cosmos
 
     # Global Refresh Rate Hz Setting
     attr_accessor :refresh_rate_hz
+
+    # Global CTS Timeout Setting
+    attr_accessor :cts_timeout
 
     # Plot types known by this tabbed plots definition
     attr_accessor :plot_types
@@ -75,6 +79,7 @@ module Cosmos
       @seconds_plotted = DEFAULT_SECONDS_PLOTTED
       @points_plotted = DEFAULT_POINTS_PLOTTED
       @refresh_rate_hz = DEFAULT_REFRESH_RATE_HZ
+      @cts_timeout = DEFAULT_CTS_TIMEOUT
       @packet_count = 0
       @configuration_errors = []
 
@@ -158,6 +163,14 @@ module Cosmos
                   @refresh_rate_hz = parameters[0].to_f
                   raise ArgumentError, "Invalid Refresh Rate Hz: #{@refresh_rate_hz}" if @refresh_rate_hz <= 0.0
 
+                when 'CTS_TIMEOUT'
+                  # Expect 1 parameter
+                  parser.verify_num_parameters(1, 1, "CTS_TIMEOUT <CTS Timeout in Seconds>")
+
+                  # Update CTS Timeout
+                  @cts_timeout = parameters[0].to_f
+                  raise ArgumentError, "Invalid CTS Timeout: #{@cts_timeout}" if @cts_timeout <= 0.0
+
                 else
                   # Handle unknown keywords
                   raise ArgumentError, "A TAB must be defined before using keyword: #{keyword}"
@@ -189,6 +202,7 @@ module Cosmos
         configuration << "POINTS_SAVED #{@points_saved}\n"
         configuration << "POINTS_PLOTTED #{@points_plotted}\n"
         configuration << "REFRESH_RATE_HZ #{@refresh_rate_hz}\n"
+        configuration << "CTS_TIMEOUT #{@cts_timeout}\n"
         @tabs.each do |tab|
           configuration << "\n"
           configuration << tab.configuration_string

--- a/lib/cosmos/tools/tlm_grapher/tabbed_plots_tool/tabbed_plots_realtime_thread.rb
+++ b/lib/cosmos/tools/tlm_grapher/tabbed_plots_tool/tabbed_plots_realtime_thread.rb
@@ -19,7 +19,7 @@ module Cosmos
 
     # Create a new TabbedPlotsRealtimeThread
     def initialize(tabbed_plots_config, connection_success_callback = nil, connection_failed_callback = nil, connection_lost_callback = nil, fatal_exception_callback = nil)
-      interface = TcpipClientInterface.new('localhost', nil, System.ports['CTS_PREIDENTIFIED'], nil, 10.0, 'PREIDENTIFIED')
+      interface = TcpipClientInterface.new('localhost', nil, System.ports['CTS_PREIDENTIFIED'], nil, tabbed_plots_config.cts_timeout, 'PREIDENTIFIED')
       super(interface)
 
       @queue = Queue.new


### PR DESCRIPTION
Added the CTS timeout option to Tlm Grapher.  I also created a new page on the website to list the Tlm Grapher config options, and added this new option to that page.

One note to the reviewer:  there is currently no way to set the CTS timeout except with the config file.  Most of the "global" TlmGrapher config options are set right on the front panel, and this didn't feel like something that belonged there.  If you disagree, let me know and I'll add a widget (there, or somewhere else if you have a better suggestion).