### PR TITLE
Extractor log analysis

### DIFF
--- a/autohotkey/tools/cmd_extractor.ahk
+++ b/autohotkey/tools/cmd_extractor.ahk
@@ -44,7 +44,7 @@ WinWaitActive Log File
 Sleep 2000
 Send {Enter} ; Done
 WinWaitActive Packet Counts
-Click 685 10 ; Close packet counts window
+Click 500 10 ; Close packet counts window
 WinWaitActive Command Extractor
 Send ^q
 

--- a/autohotkey/tools/cmd_extractor.ahk
+++ b/autohotkey/tools/cmd_extractor.ahk
@@ -29,5 +29,22 @@ Sleep 5000
 Send !f{x}      ; Exit text editor
 WinActivate Command Extractor
 WinWaitActive Command Extractor
+Send !f{a} ; Analyze logs
+WinWaitActive Warning
+Sleep 500
+Send {Enter} ;
+WinWaitActive Log File
+Click 450 305 ; Cancel
+WinWaitActive Command Extractor
+Send !f{a} ; Analyze logs
+WinWaitActive Warning
+Sleep 500
+Send {Enter} ;
+WinWaitActive Log File
+Sleep 2000
+Send {Enter} ; Done
+WinWaitActive Packet Counts
+Click 685 10 ; Close packet counts window
+WinWaitActive Command Extractor
 Send ^q
 

--- a/autohotkey/tools/tlm_extractor.ahk
+++ b/autohotkey/tools/tlm_extractor.ahk
@@ -281,7 +281,7 @@ WinWaitActive Log File
 Sleep 4000
 Send {Enter} ; Done
 WinWaitActive Packet Counts
-Click 685 10 ; Close packet counts window
+Click 265 10 ; Close packet counts window
 WinWaitActive Telemetry Extractor
 
 ; Test Batch Mode

--- a/autohotkey/tools/tlm_extractor.ahk
+++ b/autohotkey/tools/tlm_extractor.ahk
@@ -259,6 +259,31 @@ WinWaitActive Confirm
 Send {Tab}{Enter}
 WinWaitActive Telemetry Extractor
 
+; Test Log Analyze
+Send !f{a} ; Analyze logs
+WinWaitActive Warning
+Sleep 500
+Send {Enter} ;
+WinWaitActive Warning
+Sleep 500
+Send {Enter} ;
+WinWaitActive Log File
+Click 450 305 ; Cancel
+WinWaitActive Telemetry Extractor
+Send !f{a} ; Analyze logs
+WinWaitActive Warning
+Sleep 500
+Send {Enter} ;
+WinWaitActive Warning
+Sleep 500
+Send {Enter} ;
+WinWaitActive Log File
+Sleep 4000
+Send {Enter} ; Done
+WinWaitActive Packet Counts
+Click 685 10 ; Close packet counts window
+WinWaitActive Telemetry Extractor
+
 ; Test Batch Mode
 Click 665 713 ; Clear Time Start
 Sleep 100

--- a/demo/config/tools/example_application.css
+++ b/demo/config/tools/example_application.css
@@ -1,3 +1,4 @@
+/* Rename this file to application.css to set a global style */
 QMainWindow {
   background-color: #d1d1d2;
 }

--- a/lib/cosmos/gui/utilities/analyze_log.rb
+++ b/lib/cosmos/gui/utilities/analyze_log.rb
@@ -53,11 +53,23 @@ module Cosmos
         end
 
         if !@cancel
-          if pkt_counts.empty?
-            results = "No files analyzed"
+          results = "Log Analysis Complete.\n"
+          results << "Log Reader: #{@packet_log_reader.class.to_s}\n"
+          if @time_start
+            results << "Start time: #{@time_start.formatted}\n"
           else
-            results = ""
+            results << "Start time: not specified\n"
+          end
+          if @time_end
+            results << "End time:   #{@time_end.formatted}\n"
+          else
+            results << "End time:   not specified\n"
+          end
+          results << "\n"
 
+          if pkt_counts.empty?
+            results << "No files analyzed"
+          else
             if pkt_counts.keys.size > 1
               pkt_counts_total = {}
               pkt_counts.each do |file, counts|

--- a/lib/cosmos/gui/utilities/analyze_log.rb
+++ b/lib/cosmos/gui/utilities/analyze_log.rb
@@ -1,0 +1,141 @@
+# encoding: ascii-8bit
+
+# Copyright 2014 Ball Aerospace & Technologies Corp.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+
+module Cosmos
+
+  # Class to analyze log files and report packet counts.
+  class AnalyzeLog
+
+    def initialize(parent, packet_log_frame)
+      @parent = parent
+      @packet_log_frame = packet_log_frame
+      @input_filenames = []
+      @packet_log_reader = System.default_packet_log_reader.new
+      @time_start = nil
+      @time_end = nil
+      @cancel = false
+    end
+
+    def analyze_log_files
+      @cancel = false
+      pkt_counts = {}
+      begin
+        @packet_log_reader = @packet_log_frame.packet_log_reader
+        @input_filenames = @packet_log_frame.filenames.sort
+        @time_start = @packet_log_frame.time_start
+        @time_end = @packet_log_frame.time_end
+        unless @input_filenames and @input_filenames[0]
+          Qt::MessageBox.critical(@parent, 'Error', 'Please select at least 1 input file')
+          return
+        end
+
+        ProgressDialog.execute(@parent, # parent
+                               'Log File Progress', # title
+                               600, # width, height
+                               300) do |progress_dialog|
+          progress_dialog.cancel_callback = method(:cancel_callback)
+          progress_dialog.enable_cancel_button
+
+          begin
+            Cosmos.set_working_dir do
+              pkt_counts = analyze_files(progress_dialog)
+            end
+          ensure
+            progress_dialog.complete
+          end
+        end
+
+        if !@cancel
+          if pkt_counts.empty?
+            results = "No files analyzed"
+          else
+            results = ""
+
+            if pkt_counts.keys.size > 1
+              pkt_counts_total = {}
+              pkt_counts.each do |file, counts|
+                counts.each do |pkt, count|
+                  pkt_counts_total[pkt] ||= 0
+                  pkt_counts_total[pkt] += count
+                end
+              end
+              results << "Total count of packets found in all files:\n"
+              pkt_counts_total.keys.sort.each do |pkt|
+                results << "#{pkt}: #{pkt_counts_total[pkt]}\n"
+              end
+              results << "\n"
+            end
+
+            pkt_counts.each do |file, counts|
+              results << "Packets found in file: #{file}\n"
+              if counts.empty?
+                results << "  No packets found\n"
+              else
+                counts.keys.sort.each do |pkt|
+                  results << "#{pkt}: #{counts[pkt]}\n"
+                end
+              end
+              results << "\n"
+            end
+          end
+          ScrollTextDialog.new(@parent, 'Packet Counts', results)
+        end
+
+      rescue => error
+        Qt::MessageBox.critical(@parent, 'Error!', "Error Analyzing Log File(s)\n#{error.formatted}")
+      end
+    end
+
+    def analyze_files(progress_dialog)
+      log_file_count = 1
+      pkt_counts = {}
+      @input_filenames.each do |log_file|
+        break if @cancel
+        begin
+          Cosmos.check_log_configuration(@packet_log_reader, log_file)
+          file_size = File.size(log_file).to_f
+          progress_dialog.append_text("Analyzing File #{log_file_count}/#{@input_filenames.length}: #{log_file}")
+          progress_dialog.set_step_progress(0.0)
+          @packet_log_reader.each(
+            log_file, # log filename
+            true,     # identify and define packet
+            @time_start,
+            @time_end) do |packet|
+
+            break if @cancel
+            progress_dialog.set_step_progress(@packet_log_reader.bytes_read / file_size)
+            pkt_counts[log_file] ||= {}
+            pkt_counts[log_file]["#{packet.target_name} #{packet.packet_name}"] ||= 0
+            pkt_counts[log_file]["#{packet.target_name} #{packet.packet_name}"] += 1       
+          end
+          progress_dialog.set_step_progress(1.0) if !@cancel
+          progress_dialog.set_overall_progress(log_file_count.to_f / @input_filenames.length.to_f) if !@cancel
+        rescue Exception => error
+          progress_dialog.append_text("Error analyzing: #{error.formatted}\n")
+        end
+        log_file_count += 1
+      end
+      return pkt_counts
+    end
+
+    def cancel_callback(progress_dialog = nil)
+      @cancel = true
+      return true, false
+    end
+
+    def self.execute(parent, packet_log_frame)
+      log_analyzer = AnalyzeLog.new(parent, packet_log_frame)
+      log_analyzer.analyze_log_files()
+    end
+
+
+  end # class AnalyzeLog
+
+end # module Cosmos

--- a/lib/cosmos/tools/cmd_extractor/cmd_extractor.rb
+++ b/lib/cosmos/tools/cmd_extractor/cmd_extractor.rb
@@ -53,6 +53,11 @@ module Cosmos
     def initialize_actions
       super()
 
+      # File Menu Actions
+      @analyze_log = Qt::Action.new(tr('&Analyze Logs'), self)
+      @analyze_log.statusTip = tr('Analyze log file packet counts')
+      @analyze_log.connect(SIGNAL('triggered()')) { analyze_log_files() }
+
       # Mode Menu Actions
       @include_raw = Qt::Action.new(tr('Include &Raw Data'), self)
       @include_raw_keyseq = Qt::KeySequence.new(tr('Ctrl+R'))
@@ -64,6 +69,8 @@ module Cosmos
     def initialize_menus
       # File Menu
       @file_menu = menuBar.addMenu(tr('&File'))
+      @file_menu.addAction(@analyze_log)
+      @file_menu.addSeparator()
       @file_menu.addAction(@exit_action)
 
       # Mode Menu
@@ -90,12 +97,8 @@ module Cosmos
       @sep2.setFrameStyle(Qt::Frame::HLine | Qt::Frame::Sunken)
       @top_layout.addWidget(@sep2)
 
-      # Analyze, Process and Open Buttons
+      # Process and Open Buttons
       @button_layout = Qt::HBoxLayout.new
-      @analyze_button = Qt::PushButton.new('&Analyze Files')
-      @analyze_button.connect(SIGNAL('clicked()')) { analyze_log_files() }
-      @button_layout.addWidget(@analyze_button)
-
       @process_button = Qt::PushButton.new('&Process Files')
       @process_button.connect(SIGNAL('clicked()')) { process_log_files() }
       @button_layout.addWidget(@process_button)

--- a/lib/cosmos/tools/cmd_extractor/cmd_extractor.rb
+++ b/lib/cosmos/tools/cmd_extractor/cmd_extractor.rb
@@ -14,6 +14,7 @@ Cosmos.catch_fatal_exception do
   require 'cosmos/gui/dialogs/packet_log_dialog'
   require 'cosmos/gui/dialogs/splash'
   require 'cosmos/gui/dialogs/progress_dialog'
+  require 'cosmos/gui/utilities/analyze_log'
 end
 
 module Cosmos
@@ -89,8 +90,12 @@ module Cosmos
       @sep2.setFrameStyle(Qt::Frame::HLine | Qt::Frame::Sunken)
       @top_layout.addWidget(@sep2)
 
-      # Process and Open Buttons
+      # Analyze, Process and Open Buttons
       @button_layout = Qt::HBoxLayout.new
+      @analyze_button = Qt::PushButton.new('&Analyze Files')
+      @analyze_button.connect(SIGNAL('clicked()')) { analyze_log_files() }
+      @button_layout.addWidget(@analyze_button)
+
       @process_button = Qt::PushButton.new('&Process Files')
       @process_button.connect(SIGNAL('clicked()')) { process_log_files() }
       @button_layout.addWidget(@process_button)
@@ -120,6 +125,10 @@ module Cosmos
     ###############################################################################
     # File Menu Handlers
     ###############################################################################
+
+    def analyze_log_files
+      AnalyzeLog.execute(self, @packet_log_frame)
+    end
 
     def process_log_files
       @cancel = false

--- a/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
+++ b/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
@@ -120,6 +120,10 @@ module Cosmos
       @file_options.statusTip = tr('Open the options dialog')
       @file_options.connect(SIGNAL('triggered()')) { handle_options() }
 
+      @analyze_log = Qt::Action.new(tr('&Analyze Logs'), self)
+      @analyze_log.statusTip = tr('Analyze log file packet counts')
+      @analyze_log.connect(SIGNAL('triggered()')) { analyze_log_files() }
+
       # Mode Menu Actions
       @fill_down_check = Qt::Action.new(tr('&Fill Down'), self)
       @fill_down_check_keyseq = Qt::KeySequence.new(tr('Ctrl+F'))
@@ -175,6 +179,7 @@ module Cosmos
       @file_menu.addAction(@save_config)
       @file_menu.addSeparator()
       @file_menu.addAction(@file_options)
+      @file_menu.addAction(@analyze_log)
       @file_menu.addSeparator()
       @file_menu.addAction(@exit_action)
 
@@ -367,12 +372,8 @@ module Cosmos
       @packet_log_frame.change_callback = method(:change_callback)
       @file_box_layout.addWidget(@packet_log_frame)
 
-      # Analyze, Process and Open Buttons
+      # Process and Open Buttons
       @button_layout = Qt::HBoxLayout.new
-      @analyze_button = Qt::PushButton.new('&Analyze Files')
-      @analyze_button.connect(SIGNAL('clicked()')) { analyze_log_files() }
-      @button_layout.addWidget(@analyze_button)
-
       @process_button = Qt::PushButton.new('&Process Files')
       @process_button.connect(SIGNAL('clicked()')) { process_log_files() }
       @button_layout.addWidget(@process_button)

--- a/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
+++ b/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
@@ -19,6 +19,7 @@ Cosmos.catch_fatal_exception do
   require 'cosmos/gui/widgets/packet_log_frame'
   require 'cosmos/gui/dialogs/progress_dialog'
   require 'cosmos/gui/widgets/full_text_search_line_edit'
+  require 'cosmos/gui/utilities/analyze_log'
 end
 
 module Cosmos
@@ -366,8 +367,11 @@ module Cosmos
       @packet_log_frame.change_callback = method(:change_callback)
       @file_box_layout.addWidget(@packet_log_frame)
 
-      # Process and Open Buttons
+      # Analyze, Process and Open Buttons
       @button_layout = Qt::HBoxLayout.new
+      @analyze_button = Qt::PushButton.new('&Analyze Files')
+      @analyze_button.connect(SIGNAL('clicked()')) { analyze_log_files() }
+      @button_layout.addWidget(@analyze_button)
 
       @process_button = Qt::PushButton.new('&Process Files')
       @process_button.connect(SIGNAL('clicked()')) { process_log_files() }
@@ -512,6 +516,10 @@ module Cosmos
     ###############################################################################
     # File Menu Handlers
     ###############################################################################
+
+    def analyze_log_files
+      AnalyzeLog.execute(self, @packet_log_frame)
+    end
 
     # Handles processing log files
     def process_log_files


### PR DESCRIPTION
I implemented the log analysis functionality as a GUI utility so it could be used by both TlmExtractor and CmdExtractor.  I didn't make it a dialog, as it uses two other existing dialogs separately.  If there is a cleaner/better way to do this, let me know.

The part of this I'm really not sure about is the addition/placement of the "Analyze" button on both CmdExtractor and TlmExtractor.  That's a pretty significant change to the main panel on those tools, and I'm not sure it belongs.  I thought about adding a button to the log file selector panel itself, but that felt even worse.  I'm looking for feedback here before I proceed.

If this change is ok as-is, I'll still have some work to do on the autohotkey tests, so this pull request isn't complete either way.