### PR TITLE
re #347 Add a system-level keyword to specify that COSMOS should glob…

### DIFF
--- a/demo/lib/example_background_task.rb
+++ b/demo/lib/example_background_task.rb
@@ -31,7 +31,7 @@ module Cosmos
           begin
             cmd('INST', 'COLLECT', 'TYPE' => 'NORMAL', 'DURATION' => 1)
             sent_count += 1
-            @status = "Sent COLLECT ##{sent_count} at #{Time.now.formatted}"
+            @status = "Sent COLLECT ##{sent_count} at #{Time.now.sys.formatted}"
           rescue
             # Oh well - probably disconnected
           end
@@ -40,12 +40,12 @@ module Cosmos
         end
         return if @sleeper.sleep(1)
       end
-      @status = "Finished at #{Time.now.formatted}"
+      @status = "Finished at #{Time.now.sys.formatted}"
     end
 
     def stop
       @sleeper.cancel
-      @status = "Stopped at #{Time.now.formatted}"
+      @status = "Stopped at #{Time.now.sys.formatted}"
     end
   end
 end

--- a/demo/lib/example_target.rb
+++ b/demo/lib/example_target.rb
@@ -57,7 +57,7 @@ module Cosmos
           begin
             while true
               packet.write('PACKET_ID', 1)
-              packet.write('STRING', "The time is now: #{Time.now.formatted}")
+              packet.write('STRING', "The time is now: #{Time.now.sys.formatted}")
               @interface.write(packet)
               break if @sleeper.sleep(1)
             end

--- a/lib/cosmos/conversions/unix_time_conversion.rb
+++ b/lib/cosmos/conversions/unix_time_conversion.rb
@@ -31,18 +31,18 @@ module Cosmos
     # @return [Float] Packet time in seconds since UNIX epoch
     def call(value, packet, buffer)
       if @microseconds_item_name
-        return Time.at(packet.read(@seconds_item_name, :RAW, buffer), packet.read(@microseconds_item_name, :RAW, buffer))
+        return Time.at(packet.read(@seconds_item_name, :RAW, buffer), packet.read(@microseconds_item_name, :RAW, buffer)).sys
       else
-        return Time.at(packet.read(@seconds_item_name, :RAW, buffer), 0)
+        return Time.at(packet.read(@seconds_item_name, :RAW, buffer), 0).sys
       end
     end
 
     # @return [String] The name of the class followed by the time conversion
     def to_s
       if @microseconds_item_name
-        return "Time.at(packet.read('#{@seconds_item_name}', :RAW, buffer), packet.read('#{@microseconds_item_name}', :RAW, buffer))"
+        return "Time.at(packet.read('#{@seconds_item_name}', :RAW, buffer), packet.read('#{@microseconds_item_name}', :RAW, buffer)).sys"
       else
-        return "Time.at(packet.read('#{@seconds_item_name}', :RAW, buffer), 0)"
+        return "Time.at(packet.read('#{@seconds_item_name}', :RAW, buffer), 0).sys"
       end
     end
 

--- a/lib/cosmos/core_ext/file.rb
+++ b/lib/cosmos/core_ext/file.rb
@@ -34,7 +34,7 @@ class File
   # the date before appending the extension.
   #
   # For example:
-  #   File.build_timestamped_filename(['test','only'], '.bin', Time.now)
+  #   File.build_timestamped_filename(['test','only'], '.bin', Time.now.sys)
   #   # result is YYYY_MM_DD_HH_MM_SS_test_only.bin
   #
   # @param tags [Array<String>] An array of strings to be joined by underscores
@@ -43,7 +43,7 @@ class File
   # @param time [Time] The time to format into the filename
   # @return [String] The filename string containing the timestamp, tags, and
   #   extension
-  def self.build_timestamped_filename(tags = nil, extension = '.txt', time = Time.now)
+  def self.build_timestamped_filename(tags = nil, extension = '.txt', time = Time.now.sys)
     timestamp = sprintf("%04u_%02u_%02u_%02u_%02u_%02u", time.year, time.month, time.mday, time.hour, time.min, time.sec)
     tags ||= []
     tags.compact!

--- a/lib/cosmos/core_ext/time.rb
+++ b/lib/cosmos/core_ext/time.rb
@@ -68,66 +68,29 @@ class Time
   USEC_PER_DAY_FLOAT = USEC_PER_DAY.to_f
   MINUTES_PER_DAY_FLOAT = MINUTES_PER_DAY.to_f
 
-  # Class variable that allows us to globally select whether to create
-  # UTC or local Time objects with new, now, or at.
+  # Class variable that allows us to globally select whether to use
+  # UTC or local time.
   @@use_utc = false
+  
+  # Set up the Time class so that a call to the sys method will set the 
+  # Time object being operated upon to be a UTC time. 
+  def self.use_utc
+    @@use_utc = true
+  end
+  
+  # Set up the Time class so that a call to the sys method will set the 
+  # Time object being operated upon to be a local time. 
+  def self.use_local
+    @@use_utc = false
+  end
 
-  class << self
-
-    # Set up the Time class so that Time objects created with new, now, or at 
-    # will be UTC.  Time objects created with local or mktime will still be 
-    # local. Time objects created with gm or utc will still be UTC.
-    def use_utc
-      @@use_utc = true
-    end
-
-    # Set up the Time class so that Time objects created with new, now, or at 
-    # will be local.  Time objects created with local or mktime will still be 
-    # local. Time objects created with gm or utc will still be UTC.
-    def use_local
-      @@use_utc = false
-    end
-
-    # Alias the original constructor so we can call it from the new one 
-    # we're about to create.
-    alias_method :__new__, :new  
-
-    # New constructor that returns a UTC or local time depending on 
-    # the use_utc flag.
-    def new(*args)
-      if @@use_utc
-        __new__(*args).utc
-      else
-        __new__(*args).localtime
-      end
-    end
-
-    # Alias the original "now" method so we can call it from the new one 
-    # we're about to create.
-    alias_method :__now__, :now
-
-    # New "now" method that returns a UTC or local time depending on 
-    # the use_utc flag.
-    def now(*args)
-      if @@use_utc
-        __now__(*args).utc
-      else
-        __now__(*args).localtime
-      end
-    end
-
-    # Alias the original "at" method so we can call it from the new one 
-    # we're about to create.
-    alias_method :__at__, :at
-
-    # New "at" method that returns a UTC or local time depending on
-    # the use_utc flag.
-    def at(*args)
-      if @@use_utc
-        __at__(*args).utc
-      else
-        __at__(*args).localtime
-      end
+  # Set the Time object to be either a UTC or local time depending on the
+  # use_utc flag.
+  def sys
+    if @@use_utc
+      self.utc
+    else
+      self.localtime
     end
   end
 

--- a/lib/cosmos/gui/dialogs/calendar_dialog.rb
+++ b/lib/cosmos/gui/dialogs/calendar_dialog.rb
@@ -33,7 +33,11 @@ module Cosmos
         @time = initial_time
       else
         time_now = Time.now
-        @time = Time.local(time_now.year, time_now.mon, time_now.day)
+        if time_now.utc?
+          @time = Time.utc(time_now.year, time_now.mon, time_now.day)
+        else
+          @time = Time.local(time_now.year, time_now.mon, time_now.day)
+        end
       end
       @show_time = show_time
 
@@ -54,7 +58,11 @@ module Cosmos
 
       if @show_time
         @time_layout = Qt::HBoxLayout.new
-        @time_label = Qt::Label.new('Time:')
+        if @time.utc?
+          @time_label = Qt::Label.new("Time (UTC):")
+        else
+          @time_label = Qt::Label.new("Time (UTC #{@time.strftime('%z')}):")
+        end
         @time_layout.addWidget(@time_label)
         @time_layout.addStretch
         @hour = Qt::LineEdit.new(sprintf("%02u", @time.hour))

--- a/lib/cosmos/gui/dialogs/calendar_dialog.rb
+++ b/lib/cosmos/gui/dialogs/calendar_dialog.rb
@@ -32,7 +32,7 @@ module Cosmos
       if initial_time
         @time = initial_time
       else
-        time_now = Time.now
+        time_now = Time.now.sys
         if time_now.utc?
           @time = Time.utc(time_now.year, time_now.mon, time_now.day)
         else

--- a/lib/cosmos/gui/line_graph/line_graph.rb
+++ b/lib/cosmos/gui/line_graph/line_graph.rb
@@ -250,7 +250,7 @@ module Cosmos
       @in_update_graph_size = false
 
       # Time of previous left button release
-      @previous_left_button_release_time = Time.now
+      @previous_left_button_release_time = Time.now.sys
 
       # List of line colors to use
       @color_list = ['blue','red','green','darkorange', 'gold', 'purple', 'hotpink', 'lime', 'cornflowerblue', 'brown', 'coral', 'crimson', 'indigo', 'tan', 'lightblue', 'cyan', 'peru', 'maroon','orange','navy','teal','black']
@@ -321,7 +321,7 @@ module Cosmos
     end # def mousePressEvent
 
     def mouseReleaseEvent(event)
-      left_button_release_time = Time.now
+      left_button_release_time = Time.now.sys
 
       if @error and ((left_button_release_time - @previous_left_button_release_time) < DOUBLE_CLICK_SECONDS)
         @pre_error_callback.call(self) if @pre_error_callback

--- a/lib/cosmos/gui/line_graph/line_graph_drawing.rb
+++ b/lib/cosmos/gui/line_graph/line_graph_drawing.rb
@@ -248,7 +248,7 @@ module Cosmos
       if !@show_popup_x_y && @unix_epoch_x_values
         # Determine if the value is a time stamp and should be converted
         if value > 1 && value < 2147483647
-          time = Time.at(value)
+          time = Time.at(value).sys
           time = time.utc if @utc_time
           if full_date
             time.formatted # full date with day, month, year

--- a/lib/cosmos/gui/utilities/screenshot.rb
+++ b/lib/cosmos/gui/utilities/screenshot.rb
@@ -17,8 +17,8 @@ module Cosmos
     def self.screenshot_window (window, filename)
       if !Kernel.is_windows?()
         # Delay for one second to allow any dialogs to fully clear first
-        start_time = Time.now
-        while ((Time.now - start_time) < 1.0)
+        start_time = Time.now.sys
+        while ((Time.now.sys - start_time) < 1.0)
           Qt::CoreApplication.processEvents(Qt::EventLoop::AllEvents, 1000)
         end
       end

--- a/lib/cosmos/interfaces/cmd_tlm_server_interface.rb
+++ b/lib/cosmos/interfaces/cmd_tlm_server_interface.rb
@@ -66,7 +66,7 @@ module Cosmos
             if event[0] == :LIMITS_CHANGE
               data = event[1]
               packet ||= System.telemetry.packet("COSMOS","LIMITS_CHANGE")
-              packet.received_time = Time.now
+              packet.received_time = Time.now.sys
               packet.write('PKT_ID',2)
               packet.write('TARGET', data[0])
               packet.write('PACKET', data[1])

--- a/lib/cosmos/interfaces/linc_interface.rb
+++ b/lib/cosmos/interfaces/linc_interface.rb
@@ -450,7 +450,7 @@ module Cosmos
       # make packet - store on object as a defined packet of type command that this handshakes
       @identified_command = System.commands.packet(interface_target_name, packet_name).clone
       @identified_command.buffer = packet_data
-      @identified_command.received_time = Time.at(handshake.read('TIME_SECONDS'), handshake.read('TIME_MICROSECONDS'))
+      @identified_command.received_time = Time.at(handshake.read('TIME_SECONDS'), handshake.read('TIME_MICROSECONDS')).sys
     end
 
     def get_cmd_guid(fieldname_guid)

--- a/lib/cosmos/interfaces/simulated_target_interface.rb
+++ b/lib/cosmos/interfaces/simulated_target_interface.rb
@@ -35,7 +35,7 @@ module Cosmos
     def connect
       unless @initialized
         # Save the current time + 10 ms as the next expected tick time
-        @next_tick_time = Time.now + 0.01
+        @next_tick_time = Time.now.sys + 0.01
 
         # Create Simulated Target Object
         @sim_target = @sim_target_class.new(@target_names[0])
@@ -62,14 +62,14 @@ module Cosmos
 
         while true
           # Calculate time to sleep to make ticks 10ms apart
-          now = Time.now
+          now = Time.now.sys
           delta = @next_tick_time - now
           if delta > 0.0
             sleep(delta) # Sleep up to 10 ms
             return nil unless @connected
           elsif delta < -1.0
             # Fell way behind - jump next tick time
-            @next_tick_time = Time.now
+            @next_tick_time = Time.now.sys
           end
 
           @pending_packets = @sim_target.read(@count_100hz, @next_tick_time)

--- a/lib/cosmos/io/json_drb.rb
+++ b/lib/cosmos/io/json_drb.rb
@@ -297,7 +297,7 @@ module Cosmos
           while true
             begin
               request_data = JsonDRb.receive_message(my_socket, data, pipe_reader)
-              start_time = Time.now
+              start_time = Time.now.sys
               @request_count += 1
             rescue Errno::ECONNRESET, Errno::ECONNABORTED, Errno::ENOTSOCK, IOError
               # Socket was closed
@@ -373,7 +373,7 @@ module Cosmos
       response_data = response.to_json(:allow_nan => true)
       STDOUT.puts response_data if JsonDRb.debug?
       JsonDRb.send_data(socket, response_data)
-      end_time = Time.now
+      end_time = Time.now.sys
       request_time = end_time - start_time
       add_request_time(request_time)
     rescue

--- a/lib/cosmos/io/raw_logger.rb
+++ b/lib/cosmos/io/raw_logger.rb
@@ -66,7 +66,7 @@ module Cosmos
       @mutex = Mutex.new
       @file = nil
       @filename = nil
-      @start_time = Time.now
+      @start_time = Time.now.sys
       @logging_enabled = ConfigParser.handle_true_false(logging_enabled)
     end
 
@@ -107,7 +107,7 @@ module Cosmos
     # not created until data is written by {#write} so this does not
     # immediately create a log file on the filesystem.
     def start
-      close_file() unless ((Time.now - @start_time) < 1.0) # Prevent close/open too fast
+      close_file() unless ((Time.now.sys - @start_time) < 1.0) # Prevent close/open too fast
       @mutex.synchronize { @logging_enabled = true }
     end
 
@@ -136,7 +136,7 @@ module Cosmos
           @filename = File.join(@log_directory, File.build_timestamped_filename([@log_name], '.bin'))
           @file = File.new(@filename, 'wb')
         end
-        @start_time = Time.now
+        @start_time = Time.now.sys
         Logger.instance.info "Raw Log File Opened : #{@filename}"
       end
     rescue => err

--- a/lib/cosmos/io/win32_serial_driver.rb
+++ b/lib/cosmos/io/win32_serial_driver.rb
@@ -97,14 +97,14 @@ module Cosmos
     # (see SerialDriver#write)
     def write(data)
       # Write the data
-      time = Time.now
+      time = Time.now.sys
       bytes_to_write = data.length
       while (bytes_to_write > 0)
         bytes_written = Win32.write_file(@handle, data, data.length)
         raise "Error writing to comm port" if bytes_written <= 0
         bytes_to_write -= bytes_written
         data = data[bytes_written..-1]
-        raise Timeout::Error, "Write Timeout" if @write_timeout and (Time.now - time > @write_timeout) and bytes_to_write > 0
+        raise Timeout::Error, "Write Timeout" if @write_timeout and (Time.now.sys - time > @write_timeout) and bytes_to_write > 0
       end
     end
 

--- a/lib/cosmos/packet_logs/packet_log_reader.rb
+++ b/lib/cosmos/packet_logs/packet_log_reader.rb
@@ -299,7 +299,7 @@ module Cosmos
       time_microseconds = @file.read(4)
       return [nil, nil, nil, nil] if time_microseconds.nil? or time_microseconds.length != 4
       time_microseconds = time_microseconds.unpack('N')[0]
-      received_time = Time.at(time_seconds, time_microseconds)
+      received_time = Time.at(time_seconds, time_microseconds).sys
 
       # Read Target Name
       target_name = @file.read_length_bytes(1)

--- a/lib/cosmos/packet_logs/packet_log_writer.rb
+++ b/lib/cosmos/packet_logs/packet_log_writer.rb
@@ -89,7 +89,7 @@ module Cosmos
       @filename = nil
       @label = nil
       @entry_header = String.new
-      @start_time = Time.now
+      @start_time = Time.now.sys
 
       @cancel_threads = false
       @logging_thread = nil
@@ -196,7 +196,7 @@ module Cosmos
         @file.write(file_header)
         @file_size += file_header.length
       end
-      @start_time = Time.now
+      @start_time = Time.now.sys
       Logger.instance.info "Log File Opened : #{@filename}"
       start_new_file_hook()
     rescue => err
@@ -282,7 +282,7 @@ module Cosmos
         # The check against start_time needs to be mutex protected to prevent a packet coming in between the check
         # and closing the file
         @mutex.synchronize do
-          if @logging_enabled and @cycle_time and (Time.now - @start_time) > @cycle_time
+          if @logging_enabled and @cycle_time and (Time.now.sys - @start_time) > @cycle_time
             close_file(false)
           end
         end
@@ -300,7 +300,7 @@ module Cosmos
 
     def build_entry_header(packet)
       received_time = packet.received_time
-      received_time = Time.now unless received_time
+      received_time = Time.now.sys unless received_time
       # This is an optimization to avoid creating a new entry_header object
       # each time we create an entry_header which we do a LOT!
       @entry_header.clear

--- a/lib/cosmos/packets/commands.rb
+++ b/lib/cosmos/packets/commands.rb
@@ -135,7 +135,7 @@ module Cosmos
       command = packet(target_upcase, packet_upcase).clone
 
       # Set time, parameters, and restore defaults
-      command.received_time = Time.now
+      command.received_time = Time.now.sys
       command.given_values = params
       command.restore_defaults(command.buffer(false), params.keys)
       command.raw = raw

--- a/lib/cosmos/packets/telemetry.rb
+++ b/lib/cosmos/packets/telemetry.rb
@@ -248,7 +248,7 @@ module Cosmos
     # @return [Array(Packet)] Array of the stale packets
     def check_stale
       stale = []
-      time = Time.now
+      time = Time.now.sys
       @config.telemetry.each do |target_name, target_packets|
         target_packets.each do |packet_name, packet|
           if packet.received_time and (!packet.stale) and (time - packet.received_time > System.staleness_seconds)

--- a/lib/cosmos/script/commands.rb
+++ b/lib/cosmos/script/commands.rb
@@ -171,7 +171,7 @@ module Cosmos
       results = $cmd_tlm_server.get_cmd_time(target_name, command_name)
       if Array === results
         if results[2] and results[3]
-          results[2] = Time.at(results[2], results[3])
+          results[2] = Time.at(results[2], results[3]).sys
         end
         results.delete_at(3)
       end

--- a/lib/cosmos/script/scripting.rb
+++ b/lib/cosmos/script/scripting.rb
@@ -240,9 +240,9 @@ module Cosmos
       type_string = 'wait_tolerance'
       type_string << '_raw' if raw
       target_name, packet_name, item_name, expected_value, tolerance, timeout, polling_rate = wait_tolerance_process_args(args, type_string)
-      start_time = Time.now
+      start_time = Time.now.sys
       success, value = cosmos_script_wait_implementation_tolerance(target_name, packet_name, item_name, type, expected_value, tolerance, timeout, polling_rate)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       range = (expected_value - tolerance)..(expected_value + tolerance)
       wait_str = "WAIT: #{_upcase(target_name, packet_name, item_name)}"
       range_str = "range #{range.first} to #{range.last} with value == #{value} after waiting #{time} seconds"
@@ -272,9 +272,9 @@ module Cosmos
 
     # Wait on a custom expression to be true
     def wait_expression(exp_to_eval, timeout, polling_rate = DEFAULT_TLM_POLLING_RATE, context = nil)
-      start_time = Time.now
+      start_time = Time.now.sys
       success = cosmos_script_wait_implementation_expression(exp_to_eval, timeout, polling_rate, context)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       if success
         Logger.info "WAIT: #{exp_to_eval} is TRUE after waiting #{time} seconds"
       else
@@ -286,9 +286,9 @@ module Cosmos
     def _wait_check(raw, *args)
       type = (raw ? :RAW : :CONVERTED)
       target_name, packet_name, item_name, comparison_to_eval, timeout, polling_rate = wait_check_process_args(args, 'wait_check')
-      start_time = Time.now
+      start_time = Time.now.sys
       success, value = cosmos_script_wait_implementation(target_name, packet_name, item_name, type, comparison_to_eval, timeout, polling_rate)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       check_str = "CHECK: #{_upcase(target_name, packet_name, item_name)} #{comparison_to_eval}"
       with_value_str = "with value == #{value} after waiting #{time} seconds"
       if success
@@ -329,9 +329,9 @@ module Cosmos
       type_string << '_raw' if raw
       type = (raw ? :RAW : :CONVERTED)
       target_name, packet_name, item_name, expected_value, tolerance, timeout, polling_rate = wait_tolerance_process_args(args, type_string)
-      start_time = Time.now
+      start_time = Time.now.sys
       success, value = cosmos_script_wait_implementation_tolerance(target_name, packet_name, item_name, type, expected_value, tolerance, timeout, polling_rate)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       range = (expected_value - tolerance)..(expected_value + tolerance)
       check_str = "CHECK: #{_upcase(target_name, packet_name, item_name)}"
       range_str = "range #{range.first} to #{range.last} with value == #{value} after waiting #{time} seconds"
@@ -361,12 +361,12 @@ module Cosmos
                               timeout,
                               polling_rate = DEFAULT_TLM_POLLING_RATE,
                               context = nil)
-      start_time = Time.now
+      start_time = Time.now.sys
       success = cosmos_script_wait_implementation_expression(exp_to_eval,
                                                              timeout,
                                                              polling_rate,
                                                              context)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       if success
         Logger.info "CHECK: #{exp_to_eval} is TRUE after waiting #{time} seconds"
       else
@@ -390,7 +390,7 @@ module Cosmos
                      polling_rate = DEFAULT_TLM_POLLING_RATE)
       type = (check ? 'CHECK' : 'WAIT')
       initial_count = tlm(target_name, packet_name, 'RECEIVED_COUNT')
-      start_time = Time.now
+      start_time = Time.now.sys
       success, value = cosmos_script_wait_implementation(target_name,
                                                          packet_name,
                                                          'RECEIVED_COUNT',
@@ -398,7 +398,7 @@ module Cosmos
                                                          ">= #{initial_count + num_packets}",
                                                          timeout,
                                                          polling_rate)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       if success
         Logger.info "#{type}: #{target_name.upcase} #{packet_name.upcase} received #{value - initial_count} times after waiting #{time} seconds"
       else
@@ -612,9 +612,9 @@ module Cosmos
     end
 
     def _execute_wait(target_name, packet_name, item_name, value_type, comparison_to_eval, timeout, polling_rate)
-      start_time = Time.now
+      start_time = Time.now.sys
       success, value = cosmos_script_wait_implementation(target_name, packet_name, item_name, value_type, comparison_to_eval, timeout, polling_rate)
-      time = Time.now - start_time
+      time = Time.now.sys - start_time
       wait_str = "WAIT: #{_upcase(target_name, packet_name, item_name)} #{comparison_to_eval}"
       value_str = "with value == #{value} after waiting #{time} seconds"
       if success
@@ -629,15 +629,15 @@ module Cosmos
 
       case args.length
       when 0
-        start_time = Time.now
+        start_time = Time.now.sys
         cosmos_script_sleep()
-        time = Time.now - start_time
+        time = Time.now.sys - start_time
         Logger.info("WAIT: Indefinite for actual time of #{time} seconds")
       when 1
         if args[0].kind_of? Numeric
-          start_time = Time.now
+          start_time = Time.now.sys
           cosmos_script_sleep(args[0])
-          time = Time.now - start_time
+          time = Time.now.sys - start_time
           Logger.info("WAIT: #{args[0]} seconds with actual time of #{time} seconds")
         else
           raise "Non-numeric wait time specified"
@@ -737,8 +737,8 @@ module Cosmos
       if defined? ScriptRunnerFrame and ScriptRunnerFrame.instance
         sleep_time = 30000000 unless sleep_time # Handle infinite wait
         if sleep_time > 0.0
-          end_time = Time.now + sleep_time
-          until (Time.now >= end_time)
+          end_time = Time.now.sys + sleep_time
+          until (Time.now.sys >= end_time)
             sleep(0.01)
             if ScriptRunnerFrame.instance.pause?
               ScriptRunnerFrame.instance.perform_pause
@@ -760,20 +760,20 @@ module Cosmos
     end
 
     def _cosmos_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate)
-      end_time = Time.now + timeout
+      end_time = Time.now.sys + timeout
       exp_to_eval = yield
 
       while true
-        work_start = Time.now
+        work_start = Time.now.sys
         value = tlm_variable(target_name, packet_name, item_name, value_type)
         if eval(exp_to_eval)
           return true, value
         end
-        break if Time.now >= end_time || $cmd_tlm_disconnect
+        break if Time.now.sys >= end_time || $cmd_tlm_disconnect
 
-        delta = Time.now - work_start
+        delta = Time.now.sys - work_start
         sleep_time = polling_rate - delta
-        end_delta = end_time - Time.now
+        end_delta = end_time - Time.now.sys
         sleep_time = end_delta if end_delta < sleep_time
         sleep_time = 0 if sleep_time < 0
         canceled = cosmos_script_sleep(sleep_time)
@@ -806,19 +806,19 @@ module Cosmos
 
     # Wait on an expression to be true.
     def cosmos_script_wait_implementation_expression(exp_to_eval, timeout, polling_rate, context)
-      end_time = Time.now + timeout
+      end_time = Time.now.sys + timeout
       context = ScriptRunnerFrame.instance.script_binding if !context and defined? ScriptRunnerFrame and ScriptRunnerFrame.instance
 
       while true
-        work_start = Time.now
+        work_start = Time.now.sys
         if eval(exp_to_eval, context)
           return true
         end
-        break if Time.now >= end_time
+        break if Time.now.sys >= end_time
 
-        delta = Time.now - work_start
+        delta = Time.now.sys - work_start
         sleep_time = polling_rate - delta
-        end_delta = end_time - Time.now
+        end_delta = end_time - Time.now.sys
         sleep_time = end_delta if end_delta < sleep_time
         sleep_time = 0 if sleep_time < 0
         canceled = cosmos_script_sleep(sleep_time)

--- a/lib/cosmos/script/telemetry.rb
+++ b/lib/cosmos/script/telemetry.rb
@@ -149,7 +149,7 @@ module Cosmos
     def get_packet_data(id, non_block = false)
       results = $cmd_tlm_server.get_packet_data(id, non_block)
       if Array === results and results[3] and results[4]
-        results[3] = Time.at(results[3], results[4])
+        results[3] = Time.at(results[3], results[4]).sys
         results.delete_at(4)
       end
       results

--- a/lib/cosmos/streams/fixed_stream_protocol.rb
+++ b/lib/cosmos/streams/fixed_stream_protocol.rb
@@ -82,7 +82,7 @@ module Cosmos
             end
             # Set some variables so we can update the packet in
             # post_read_packet
-            @received_time = Time.now
+            @received_time = Time.now.sys
             @target_name = identified_packet.target_name
             @packet_name = identified_packet.packet_name
 

--- a/lib/cosmos/streams/preidentified_stream_protocol.rb
+++ b/lib/cosmos/streams/preidentified_stream_protocol.rb
@@ -35,7 +35,7 @@ module Cosmos
     # See StreamProtocol#pre_write_packet
     def pre_write_packet(packet)
       received_time = packet.received_time
-      received_time = Time.now unless received_time
+      received_time = Time.now.sys unless received_time
       time_seconds = [received_time.tv_sec].pack('N') # UINT32
       time_microseconds = [received_time.tv_usec].pack('N') # UINT32
       target_name = packet.target_name
@@ -98,7 +98,7 @@ module Cosmos
       return nil if @data.length <= 0
       time_seconds = @data[0..3].unpack('N')[0] # UINT32
       time_microseconds = @data[4..7].unpack('N')[0] # UINT32
-      @received_time = Time.at(time_seconds, time_microseconds)
+      @received_time = Time.at(time_seconds, time_microseconds).sys
       @data.replace(@data[8..-1])
 
       # Read and remove the target name

--- a/lib/cosmos/system/system.rb
+++ b/lib/cosmos/system/system.rb
@@ -58,6 +58,8 @@ module Cosmos
     instance_attr_reader :staleness_seconds
     # @return [Symbol] The current limits set
     instance_attr_reader :limits_set
+    # @return [Boolean] Whether to use UTC or local times
+    instance_attr_reader :use_utc
 
     # Known COSMOS ports
     KNOWN_PORTS = ['CTS_API', 'TLMVIEWER_API', 'CTS_PREIDENTIFIED', 'CTS_CMD_ROUTER']
@@ -89,6 +91,7 @@ module Cosmos
       @acl = nil
       @staleness_seconds = 30
       @limits_set = :DEFAULT
+      @use_utc = false
 
       @ports = {}
       @ports['CTS_API'] = 7777
@@ -218,6 +221,7 @@ module Cosmos
       @targets = {}
       # Set config to nil so things will lazy load later
       @config = nil
+      @use_utc = false
       acl_list = []
       all_allowed = false
       first_procedures_path = true
@@ -332,6 +336,10 @@ module Cosmos
             parser.verify_num_parameters(1, 1, usage)
             @cmd_tlm_version = parameters[0]
 
+          when 'TIME_ZONE_UTC'
+            parser.verify_num_parameters(0, 0, "#{keyword}")
+            @use_utc = true
+
           else
             # blank lines will have a nil keyword and should not raise an exception
             raise parser.error("Unknown keyword '#{keyword}'") if keyword
@@ -339,6 +347,13 @@ module Cosmos
         end # parser.parse_file
 
         @acl = ACL.new(acl_list, ACL::ALLOW_DENY) unless acl_list.empty?
+
+        # Explicitly set up time to use UTC or local
+        if @use_utc
+          Time.use_utc()
+        else
+          Time.use_local()
+        end
 
         # Second pass - Process targets
         process_targets(parser, filename, configuration_directory)

--- a/lib/cosmos/tools/cmd_sender/cmd_sender.rb
+++ b/lib/cosmos/tools/cmd_sender/cmd_sender.rb
@@ -341,11 +341,11 @@ module Cosmos
         dialog.dispose
       rescue Exception => err
         message = "Error sending raw file due to #{err}"
-        @message_log.write(Time.now.formatted + '  ' + message + "\n")
+        @message_log.write(Time.now.sys.formatted + '  ' + message + "\n")
         statusBar.showMessage(message)
       rescue DRb::DRbConnError
         message = "Error Connecting to Command and Telemetry Server"
-        @message_log.write(Time.now.formatted + '  ' + message + "\n")
+        @message_log.write(Time.now.sys.formatted + '  ' + message + "\n")
         statusBar.showMessage(message)
       end
     end
@@ -371,7 +371,7 @@ module Cosmos
         packet_name = @cmd_select.text
         if target_name and packet_name
           output_string, params = view_as_script()
-          @message_log.write(Time.now.formatted + '  ' + output_string + "\n")
+          @message_log.write(Time.now.sys.formatted + '  ' + output_string + "\n")
           if @cmd_raw.checked?
             if @ignore_range.checked?
               cmd_raw_no_range_check(target_name, packet_name, params)
@@ -396,12 +396,12 @@ module Cosmos
         end
       rescue DRb::DRbConnError
         message = "Error Connecting to Command and Telemetry Server"
-        @message_log.write(Time.now.formatted + '  ' + message + "\n")
+        @message_log.write(Time.now.sys.formatted + '  ' + message + "\n")
         statusBar.showMessage(message)
         Qt::MessageBox.critical(self, 'Error', message)
       rescue Exception => err
         message = "Error sending #{target_name} #{packet_name} due to #{err}"
-        @message_log.write(Time.now.formatted + '  ' + message + "\n")
+        @message_log.write(Time.now.sys.formatted + '  ' + message + "\n")
         statusBar.showMessage(message)
         Qt::MessageBox.critical(self, 'Error', message)
       end

--- a/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server.rb
@@ -396,7 +396,7 @@ module Cosmos
             packets.each do |target_name, packet_name|
               if packet.target_name == target_name and packet.packet_name == packet_name
                 received_time = packet.received_time
-                received_time ||= Time.now
+                received_time ||= Time.now.sys
                 queue << [packet.buffer, target_name, packet_name,
                   received_time.tv_sec, received_time.tv_usec, packet.received_count]
                 if queue.length > queue_size

--- a/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server_gui.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server_gui.rb
@@ -223,9 +223,9 @@ module Cosmos
       @tab_thread = Thread.new do
         begin
           while true
-            start_time = Time.now
+            start_time = Time.now.sys
             Qt.execute_in_main_thread(true) { @status_tab.update }
-            total_time = Time.now - start_time
+            total_time = Time.now.sys - start_time
             if total_time > 0.0 and total_time < 1.0
               break if @tab_sleeper.sleep(1.0 - total_time)
             end

--- a/lib/cosmos/tools/cmd_tlm_server/commanding.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/commanding.rb
@@ -45,7 +45,7 @@ module Cosmos
     # @param packet [Packet] Packet to send
     def send_command_to_interface(interface, packet)
       # Make sure packet received time is set
-      packet.received_time ||= Time.now
+      packet.received_time ||= Time.now.sys
 
       unless packet.identified?
         identified_command = System.commands.identify(packet.buffer, interface.target_names)

--- a/lib/cosmos/tools/cmd_tlm_server/interface_thread.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/interface_thread.rb
@@ -93,7 +93,7 @@ module Cosmos
                     next
                   end
                 end
-                packet.received_time = Time.now unless packet.received_time
+                packet.received_time = Time.now.sys unless packet.received_time
               rescue Exception => err
                 handle_connection_lost(err)
                 if @cancel_thread

--- a/lib/cosmos/tools/data_viewer/data_viewer.rb
+++ b/lib/cosmos/tools/data_viewer/data_viewer.rb
@@ -253,7 +253,7 @@ module Cosmos
                   else
                     Qt.execute_in_main_thread(true) { @realtime_button_bar.state = 'Running' }
                   end
-                  Qt.execute_in_main_thread(true) { statusBar.showMessage("Connected to Command and Telemetry Server: #{Time.now.formatted}") }
+                  Qt.execute_in_main_thread(true) { statusBar.showMessage("Connected to Command and Telemetry Server: #{Time.now.sys.formatted}") }
                 rescue DRb::DRbConnError
                   break if @cancel_thread
                   Qt.execute_in_main_thread(true) do
@@ -294,7 +294,7 @@ module Cosmos
                   rescue RuntimeError => error
                     raise error unless error.message =~ /queue/
                     break if @cancel_thread
-                    Qt.execute_in_main_thread(true) { statusBar.showMessage(tr("Connection Dropped by Command and Telemetry Server: #{Time.now.formatted}")) }
+                    Qt.execute_in_main_thread(true) { statusBar.showMessage(tr("Connection Dropped by Command and Telemetry Server: #{Time.now.sys.formatted}")) }
                     break # Let outer loop resubscribe
                   end
                 end

--- a/lib/cosmos/tools/packet_viewer/packet_viewer.rb
+++ b/lib/cosmos/tools/packet_viewer/packet_viewer.rb
@@ -396,7 +396,7 @@ module Cosmos
       @tlm_thread = Thread.new do
         begin
           while true
-            time = Time.now
+            time = Time.now.sys
             break if @shutdown_tlm_thread
 
             begin
@@ -475,7 +475,7 @@ module Cosmos
             # Delay for 1/10 of polling rate
             10.times do
               break if @shutdown_tlm_thread
-              sleep(@polling_rate.to_f / 10.0) if (Time.now - time < @polling_rate)
+              sleep(@polling_rate.to_f / 10.0) if (Time.now.sys - time < @polling_rate)
             end
           end
         rescue Exception => error

--- a/lib/cosmos/tools/replay/replay.rb
+++ b/lib/cosmos/tools/replay/replay.rb
@@ -330,17 +330,17 @@ module Cosmos
           previous_packet = nil
           while (@playing)
             if @playback_delay
-              packet_start = Time.now
+              packet_start = Time.now.sys
               packet = read_at_index(@playback_index, direction)
               break unless packet
               delay_time = 0.0
               if @playback_delay > 0.0
-                delay_time = @playback_delay - (Time.now - packet_start)
+                delay_time = @playback_delay - (Time.now.sys - packet_start)
               elsif previous_packet and packet.received_time and previous_packet.received_time
                 if direction == :FORWARD
-                  delay_time = packet.received_time - previous_packet.received_time - (Time.now - packet_start)
+                  delay_time = packet.received_time - previous_packet.received_time - (Time.now.sys - packet_start)
                 else
-                  delay_time = previous_packet.received_time - packet.received_time - (Time.now - packet_start)
+                  delay_time = previous_packet.received_time - packet.received_time - (Time.now.sys - packet_start)
                 end
               end
               sleep(delay_time) if delay_time > 0.0

--- a/lib/cosmos/tools/replay/replay.rb
+++ b/lib/cosmos/tools/replay/replay.rb
@@ -258,7 +258,7 @@ module Cosmos
     def move_start
       if @log_filename and !@playback_thread
         packet = read_at_index(0, :FORWARD)
-        @start_time.value = packet.received_time.formatted if packet and packet.received_time
+        @start_time.value = packet.received_time.formatted(true, 3, true) if packet and packet.received_time
       else
         stop()
       end
@@ -307,7 +307,7 @@ module Cosmos
     def move_end
       if @log_filename and !@playback_thread
         packet = read_at_index(@packet_offsets.length - 1, :FORWARD)
-        @end_time.value = packet.received_time.formatted if packet and packet.received_time
+        @end_time.value = packet.received_time.formatted(true, 3, true) if packet and packet.received_time
       else
         stop()
       end
@@ -389,7 +389,7 @@ module Cosmos
         value = (((@playback_index - 1) / @packet_offsets.length.to_f) * 10000).to_i
         @slider.setSliderPosition(value)
         @slider.setValue(value)
-        @current_time.value = packet.received_time.formatted if packet and packet.received_time
+        @current_time.value = packet.received_time.formatted(true, 3, true) if packet and packet.received_time
       end
     end
 

--- a/lib/cosmos/tools/script_runner/script_runner_frame.rb
+++ b/lib/cosmos/tools/script_runner/script_runner_frame.rb
@@ -203,7 +203,7 @@ module Cosmos
       @debug_history = []
       @debug_code_completion = nil
       @top_level_instrumented_cache = nil
-      @output_time = Time.now
+      @output_time = Time.now.sys
       initialize_variables()
 
       # Redirect $stdout and $stderr
@@ -391,7 +391,7 @@ module Cosmos
     def self.show_backtrace=(value)
       @@show_backtrace = value
       if @@show_backtrace and @@error
-        puts Time.now.formatted + " (SCRIPTRUNNER): "  + "Most recent exception:\n" + @@error.formatted
+        puts Time.now.sys.formatted + " (SCRIPTRUNNER): "  + "Most recent exception:\n" + @@error.formatted
       end
     end
 
@@ -1086,14 +1086,14 @@ module Cosmos
     end
 
     def scriptrunner_puts(string)
-      puts Time.now.formatted + " (SCRIPTRUNNER): "  + string
+      puts Time.now.sys.formatted + " (SCRIPTRUNNER): "  + string
     end
 
     def handle_output_io(filename = @current_filename, line_number = @current_line_number)
-      @output_time = Time.now
+      @output_time = Time.now.sys
       Qt.execute_in_main_thread(true) do
         if @output_io.string[-1..-1] == "\n"
-          time_formatted = Time.now.formatted
+          time_formatted = Time.now.sys.formatted
           lines_to_write = ''
           out_line_number = line_number.to_s
           out_filename = File.basename(filename) if filename
@@ -1165,7 +1165,7 @@ module Cosmos
       @use_instrumentation = true
       @active_script = @script
       @call_stack = []
-      @pre_line_time = Time.now
+      @pre_line_time = Time.now.sys
       @current_file = @filename
       @exceptions = nil
       @script_binding = nil
@@ -1291,7 +1291,7 @@ module Cosmos
 
           # Execute the script with warnings disabled
           Cosmos.disable_warnings do
-            @pre_line_time = Time.now
+            @pre_line_time = Time.now.sys
             Cosmos.set_working_dir do
               if text_binding
                 eval(instrumented_script, text_binding, @filename, 1)
@@ -1417,10 +1417,10 @@ module Cosmos
 
     def handle_line_delay
       if @@line_delay > 0.0
-        sleep_time = @@line_delay - (Time.now - @pre_line_time)
+        sleep_time = @@line_delay - (Time.now.sys - @pre_line_time)
         sleep(sleep_time) if sleep_time > 0.0
       end
-      @pre_line_time = Time.now
+      @pre_line_time = Time.now.sys
     end
 
     def continue_without_pausing_on_errors?
@@ -1717,7 +1717,7 @@ module Cosmos
       begin
         loop do
           break if @@cancel_output
-          handle_output_io() if (Time.now - @output_time) > 5.0
+          handle_output_io() if (Time.now.sys - @output_time) > 5.0
           break if @@cancel_output
           break if @@output_sleeper.sleep(1.0)
         end # loop

--- a/lib/cosmos/tools/test_runner/results_writer.rb
+++ b/lib/cosmos/tools/test_runner/results_writer.rb
@@ -40,7 +40,7 @@ module Cosmos
 
     def start(test_type, test_suite_class, test_class = nil, test_case = nil, settings = nil)
       @results = []
-      @start_time = Time.now
+      @start_time = Time.now.sys
       @filename = File.join(@path, File.build_timestamped_filename(['testrunner', 'results']))
       @data_package_filename = @filename[0..-5] + '.zip'
       Cosmos.set_working_dir do
@@ -111,7 +111,7 @@ module Cosmos
     end
 
     def complete
-      @stop_time = Time.now
+      @stop_time = Time.now.sys
       cycle_logs() if @auto_cycle_logs
       footer()
     ensure
@@ -243,12 +243,12 @@ module Cosmos
     end
 
     def write(string)
-      @file.write(Time.now.formatted + ': ' + string)
+      @file.write(Time.now.sys.formatted + ': ' + string)
       @file.flush
     end
 
     def puts(string)
-      @file.puts(Time.now.formatted + ': ' + string)
+      @file.puts(Time.now.sys.formatted + ': ' + string)
       @file.flush
     end
 

--- a/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
+++ b/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
@@ -599,7 +599,7 @@ module Cosmos
         # Configure Tlm Extractor Config
         sync_gui_to_config()
 
-        start_time = Time.now
+        start_time = Time.now.sys
         ProgressDialog.execute(self, 'Log File Progress', 600, 300) do |progress_dialog|
           progress_dialog.cancel_callback = method(:cancel_callback)
           progress_dialog.enable_cancel_button
@@ -657,7 +657,7 @@ module Cosmos
           ensure
             progress_dialog.set_step_progress(1.0) if !@cancel
             progress_dialog.set_overall_progress(1.0) if !@cancel
-            progress_dialog.append_text("Runtime: #{Time.now - start_time} s")
+            progress_dialog.append_text("Runtime: #{Time.now.sys - start_time} s")
             progress_dialog.complete
             if @batch_filenames.empty?
               Qt.execute_in_main_thread(true) do

--- a/lib/cosmos/tools/tlm_viewer/screen.rb
+++ b/lib/cosmos/tools/tlm_viewer/screen.rb
@@ -114,7 +114,7 @@ module Cosmos
           begin
             while(true)
               break if @@closing_all
-              time = Time.now
+              time = Time.now.sys
 
               begin
                 # Gather item values for value widgets
@@ -142,7 +142,7 @@ module Cosmos
               end
 
               Qt.execute_in_main_thread {update_gui()} if @alive and (@mode == :REALTIME)
-              delta = Time.now - time
+              delta = Time.now.sys - time
               break if @@closing_all
               if @polling_period - delta > 0
                 break if @value_sleeper.sleep(@polling_period - delta)

--- a/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
+++ b/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
@@ -377,7 +377,7 @@ module Cosmos
             output_filename = File.join(System.paths['LOGS'],
                                         File.build_timestamped_filename(['screen','audit'], '.txt'))
             File.open(output_filename, 'w') do |file|
-              file.puts "Telemetry Viewer audit created on #{Time.now.formatted}.\n"
+              file.puts "Telemetry Viewer audit created on #{Time.now.sys.formatted}.\n"
               if all_telemetry.empty?
                 msg = "\nAll telemetry points accounted for in screens."
                 progress.append_text(msg)

--- a/lib/cosmos/top_level.rb
+++ b/lib/cosmos/top_level.rb
@@ -705,8 +705,8 @@ module Cosmos
       if owner and owner.respond_to? :graceful_kill
         if Thread.current != thread
           owner.graceful_kill
-          end_time = Time.now + graceful_timeout
-          while thread.alive? && ((end_time - Time.now) > 0)
+          end_time = Time.now.sys + graceful_timeout
+          while thread.alive? && ((end_time - Time.now.sys) > 0)
             sleep(timeout_interval)
           end
         else
@@ -719,8 +719,8 @@ module Cosmos
         # Graceful failed
         Logger.warn "Failed to gracefully kill thread:\n  Caller Backtrace:\n  #{caller().join("\n  ")}\n  \n  Thread Backtrace:\n  #{thread.backtrace.join("\n  ")}\n\n"
         thread.kill
-        end_time = Time.now + hard_timeout
-        while thread.alive? && ((end_time - Time.now) > 0)
+        end_time = Time.now.sys + hard_timeout
+        while thread.alive? && ((end_time - Time.now.sys) > 0)
           sleep(timeout_interval)
         end
       end

--- a/lib/cosmos/utilities/logger.rb
+++ b/lib/cosmos/utilities/logger.rb
@@ -125,9 +125,9 @@ module Cosmos
     def log_message(severity_string, message, &block)
       @mutex.synchronize do
         if block_given?
-          puts "#{Time.now.formatted} #{@detail_string ? "(#{@detail_string}):" : ''}#{severity_string} " << yield
+          puts "#{Time.now.sys.formatted} #{@detail_string ? "(#{@detail_string}):" : ''}#{severity_string} " << yield
         else
-          puts "#{Time.now.formatted} #{@detail_string ? "(#{@detail_string}):" : ''}#{severity_string} #{message}"
+          puts "#{Time.now.sys.formatted} #{@detail_string ? "(#{@detail_string}):" : ''}#{severity_string} #{message}"
         end
       end
     end

--- a/spec/conversions/unix_time_formatted_conversion_spec.rb
+++ b/spec/conversions/unix_time_formatted_conversion_spec.rb
@@ -61,12 +61,12 @@ module Cosmos
     describe "to_s" do
       it "returns the seconds conversion" do
         gc = UnixTimeFormattedConversion.new('TIME')
-        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), 0).formatted"
+        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), 0).sys.formatted"
       end
 
       it "returns the microseconds conversion" do
         gc = UnixTimeFormattedConversion.new('TIME','TIME_US')
-        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), packet.read('TIME_US', :RAW, buffer)).formatted"
+        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), packet.read('TIME_US', :RAW, buffer)).sys.formatted"
       end
     end
   end

--- a/spec/conversions/unix_time_seconds_conversion_spec.rb
+++ b/spec/conversions/unix_time_seconds_conversion_spec.rb
@@ -63,12 +63,12 @@ module Cosmos
     describe "to_s" do
       it "returns the seconds conversion" do
         gc = UnixTimeSecondsConversion.new('TIME')
-        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), 0).to_f"
+        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), 0).sys.to_f"
       end
 
       it "returns the microseconds conversion" do
         gc = UnixTimeSecondsConversion.new('TIME','TIME_US')
-        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), packet.read('TIME_US', :RAW, buffer)).to_f"
+        expect(gc.to_s).to eql "Time.at(packet.read('TIME', :RAW, buffer), packet.read('TIME_US', :RAW, buffer)).sys.to_f"
       end
     end
   end

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -207,4 +207,14 @@ describe Time do
       expect(Time.init_epoch_delta("1969/12/31 12:00:00")).to eql 60*60*12
     end
   end
+
+  describe "Time.sys" do
+    it "converts time to UTC or local" do
+      Time.use_utc
+      expect(Time.now.sys.utc?).to eql true
+      Time.use_local
+      expect(Time.now.sys.utc?).to eql false
+    end
+  end
+
 end


### PR DESCRIPTION
…ally use UTC times.

Note to reviewer:  Under the hood, this implementation uses a monkey patch to the Time class so that Time objects created with new, now, and at are set up to be local or UTC depending on the system setting.  I know touching core classes that way is a scary proposition, but this was the only way that I could come up with to consistently apply a Time Zone setting all across COSMOS.  Another option would maybe be to derive a special CosmosTime class, but that seems like it'd be a lot of search'n'replace work, and hard to enforce usage in the future.