### PR TITLE
re #477 Eliminate usage of userpath.txt

### DIFF
--- a/autohotkey/userpath.txt
+++ b/autohotkey/userpath.txt
@@ -1,1 +1,0 @@
-DO NOT DELETE THIS FILE!  It is used by cosmos.rb to build the ::Cosmos::USERPATH directory.

--- a/demo/userpath.txt
+++ b/demo/userpath.txt
@@ -1,1 +1,0 @@
-DO NOT DELETE THIS FILE!  It is used by cosmos.rb to build the ::Cosmos::USERPATH directory.

--- a/install/userpath.txt
+++ b/install/userpath.txt
@@ -1,1 +1,0 @@
-DO NOT DELETE THIS FILE!  It is used by cosmos.rb to build the ::Cosmos::USERPATH directory.

--- a/lib/cosmos/top_level.rb
+++ b/lib/cosmos/top_level.rb
@@ -70,15 +70,17 @@ module Cosmos
     $VERBOSE = saved_verbose
   end
 
-  # Searches for the file userpath.txt to define the USERPATH constant
+  # Searches for the /config/system and /config/targets directories to define 
+  # the USERPATH constant
   #
-  # @param start_dir [String] Path to start the search for userpath.txt. The
-  #   search will continue by moving up directories until the root directory is
-  #   reached.
+  # @param start_dir [String] Path to start the search for the /config/system
+  #   and /config/targets directories.  The search will continue by moving up
+  #   directories until the root directory is reached.
   def self.define_user_path(start_dir = Dir.pwd)
     current_dir = File.expand_path(start_dir)
     while true
-      if File.exist?(File.join(current_dir, 'userpath.txt'))
+      if File.exist?(File.join(current_dir, 'config', 'system')) and 
+         File.exist?(File.join(current_dir, 'config', 'targets'))
         disable_warnings do
           Cosmos.const_set(:USERPATH, current_dir)
         end
@@ -113,7 +115,7 @@ module Cosmos
           Cosmos.const_set(:USERPATH, ENV['COSMOS_USERPATH'])
         end
       else
-        # Give up and assume we are in the tools directory and there is no userpath.txt file
+        # Give up and assume we are in the tools directory
         disable_warnings do
           Cosmos.const_set(:USERPATH, File.expand_path(File.join(File.dirname($0), '..')))
         end

--- a/spec/install/userpath.txt
+++ b/spec/install/userpath.txt
@@ -1,1 +1,0 @@
-DO NOT DELETE THIS FILE!  It is used by cosmos.rb to build the ::Cosmos::USERPATH directory.

--- a/spec/top_level/top_level_spec.rb
+++ b/spec/top_level/top_level_spec.rb
@@ -70,21 +70,22 @@ module Cosmos
       expect(Cosmos::USERPATH).not_to be_nil
     end
 
-    context "when searching for userpath.txt" do
+    context "when searching for config/system and config/targets" do
       it "giveups if it can't be found" do
         old = Cosmos::USERPATH
         Cosmos.define_user_path(Dir.home)
         expect(Cosmos::USERPATH).to eql old
       end
 
-      it "sets the path to where userpath.txt is found" do
+      it "sets the path to where config/system and config/targets are found" do
         ENV.delete('COSMOS_USERPATH')
         old = Cosmos::USERPATH
         expect(old).not_to eql File.dirname(__FILE__)
-        File.open(File.join(File.dirname(__FILE__), 'userpath.txt'),'w') {|f| f.puts '' }
+        FileUtils.mkdir_p(File.join(File.dirname(__FILE__), 'config', 'system'))
+        FileUtils.mkdir_p(File.join(File.dirname(__FILE__), 'config', 'targets'))
         Cosmos.define_user_path(File.dirname(__FILE__))
         expect(Cosmos::USERPATH).to eql File.dirname(__FILE__)
-        File.delete(File.join(File.dirname(__FILE__), 'userpath.txt'))
+        FileUtils.rm_rf(File.join(File.dirname(__FILE__), 'config'))
       end
     end
   end

--- a/test/performance/userpath.txt
+++ b/test/performance/userpath.txt
@@ -1,1 +1,0 @@
-DO NOT DELETE THIS FILE!  It is used by cosmos.rb to build the ::Cosmos::USERPATH directory.


### PR DESCRIPTION
See the note I made in the ticket (#477) about using config/targets instead of config/data.  If you don't like that, it's an easy change.