### PR TITLE
re #323 Catch SIGINT and SIGTERM and shutdown CTS gracefully when run…

### DIFF
--- a/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server_gui.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server_gui.rb
@@ -344,6 +344,9 @@ module Cosmos
 
     def self.post_options_parsed_hook(options)
       if options.no_gui
+        Signal.trap("TERM") {exit}
+        Signal.trap("INT") {exit}
+
         begin
           @output_sleeper = Sleeper.new
           @string_output = StringIO.new("", "r+")


### PR DESCRIPTION
…ning in --no-gui mode.

Note:  to test this change I ran the Demo CTS in --no-gui mode on a CentOS box and shut it down with CTRL-C, kill -TERM, and kill -INT.  Before making this change the CTS would shutdown gracefully for CTRL-C and SIGINT, but would crash for SIGTERM.  Now it shuts down gracefully for all 3 shutdown methods.  By shuts down gracefully, I mean you can see all interfaces and threads closing down and it doesn't complain of an exception before exiting.