### PR TITLE
closes #517. Make hosts configurable

### DIFF
--- a/demo/config/system/system.txt
+++ b/demo/config/system/system.txt
@@ -8,10 +8,23 @@ DECLARE_TARGET EXAMPLE
 DECLARE_TARGET TEMPLATED
 DECLARE_TARGET SYSTEM
 
+# Listen Hosts - Ip addresses or hostnames to listen on when running the tools
+LISTEN_HOST CTS_API 127.0.0.1
+LISTEN_HOST TLMVIEWER_API 127.0.0.1
+LISTEN_HOST CTS_PREIDENTIFIED 0.0.0.0 # 127.0.0.1 is more secure if you don't need external connections
+LISTEN_HOST CTS_CMD_ROUTER 0.0.0.0 # 127.0.0.1 is more secure if you don't need external connections
+
+# Connect Hosts - Ip addresses or hostnames to connect to when running the tools
+CONNECT_HOST CTS_API 127.0.0.1
+CONNECT_HOST TLMVIEWER_API 127.0.0.1
+CONNECT_HOST CTS_PREIDENTIFIED 127.0.0.1
+CONNECT_HOST CTS_CMD_ROUTER 127.0.0.1
+
 # Ethernet Ports
 PORT CTS_API 7777
 PORT TLMVIEWER_API 7778
 PORT CTS_PREIDENTIFIED 7779
+PORT CTS_CMD_ROUTER 7780
 
 # Default Packet Log Writer and Reader
 DEFAULT_PACKET_LOG_WRITER packet_log_writer.rb

--- a/demo/config/system/system2.txt
+++ b/demo/config/system/system2.txt
@@ -7,10 +7,23 @@ DECLARE_TARGET INST INST2
 DECLARE_TARGET EXAMPLE
 DECLARE_TARGET SYSTEM
 
+# Listen Hosts - Ip addresses or hostnames to listen on when running the tools
+LISTEN_HOST CTS_API 127.0.0.1
+LISTEN_HOST TLMVIEWER_API 127.0.0.1
+LISTEN_HOST CTS_PREIDENTIFIED 0.0.0.0 # 127.0.0.1 is more secure if you don't need external connections
+LISTEN_HOST CTS_CMD_ROUTER 0.0.0.0 # 127.0.0.1 is more secure if you don't need external connections
+
+# Connect Hosts - Ip addresses or hostnames to connect to when running the tools
+CONNECT_HOST CTS_API 127.0.0.1
+CONNECT_HOST TLMVIEWER_API 127.0.0.1
+CONNECT_HOST CTS_PREIDENTIFIED 127.0.0.1
+CONNECT_HOST CTS_CMD_ROUTER 127.0.0.1
+
 # Ethernet Ports
 PORT CTS_API 8777
 PORT TLMVIEWER_API 8778
 PORT CTS_PREIDENTIFIED 8779
+PORT CTS_CMD_ROUTER 7780
 
 # Default Packet Log Writer and Reader
 DEFAULT_PACKET_LOG_WRITER packet_log_writer.rb

--- a/install/config/system/system.txt
+++ b/install/config/system/system.txt
@@ -4,10 +4,23 @@
 AUTO_DECLARE_TARGETS
 # DECLARE_TARGET SYSTEM
 
+# Listen Hosts - Ip addresses or hostnames to listen on when running the tools
+LISTEN_HOST CTS_API 127.0.0.1
+LISTEN_HOST TLMVIEWER_API 127.0.0.1
+LISTEN_HOST CTS_PREIDENTIFIED 0.0.0.0 # 127.0.0.1 is more secure if you don't need external connections
+LISTEN_HOST CTS_CMD_ROUTER 0.0.0.0 # 127.0.0.1 is more secure if you don't need external connections
+
+# Connect Hosts - Ip addresses or hostnames to connect to when running the tools
+CONNECT_HOST CTS_API 127.0.0.1
+CONNECT_HOST TLMVIEWER_API 127.0.0.1
+CONNECT_HOST CTS_PREIDENTIFIED 127.0.0.1
+CONNECT_HOST CTS_CMD_ROUTER 127.0.0.1
+
 # Ethernet Ports
 PORT CTS_API 7777
 PORT TLMVIEWER_API 7778
 PORT CTS_PREIDENTIFIED 7779
+PORT CTS_CMD_ROUTER 7780
 
 # Default Packet Log Writer and Reader
 DEFAULT_PACKET_LOG_WRITER packet_log_writer.rb

--- a/lib/cosmos/script/script.rb
+++ b/lib/cosmos/script/script.rb
@@ -49,7 +49,7 @@ module Cosmos
         $cmd_tlm_server = CmdTlmServer.new(config_file, false, true)
       else
         # Start a Json connect to the real CTS server
-        $cmd_tlm_server = JsonDRbObject.new('127.0.0.1', System.ports['CTS_API'])
+        $cmd_tlm_server = JsonDRbObject.new(System.connect_hosts['CTS_API'], System.ports['CTS_API'])
       end
     end
 

--- a/lib/cosmos/script/tools.rb
+++ b/lib/cosmos/script/tools.rb
@@ -36,7 +36,7 @@ module Cosmos
     end
 
     def run_tlm_viewer(action, display_name = '')
-      tlm_viewer = JsonDRbObject.new "localhost", System.ports['TLMVIEWER_API']
+      tlm_viewer = JsonDRbObject.new System.connect_hosts['TLMVIEWER_API'], System.ports['TLMVIEWER_API']
       begin
         yield tlm_viewer
         tlm_viewer.disconnect

--- a/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/cmd_tlm_server.rb
@@ -71,8 +71,6 @@ module Cosmos
     #   packet_data_queues hash to access the queue.
     attr_accessor :next_packet_data_queue_id
 
-    # The default host
-    DEFAULT_HOST = 'localhost'
     # The default configuration file name
     DEFAULT_CONFIG_FILE = File.join(Cosmos::USERPATH, 'config', 'tools', 'cmd_tlm_server', 'cmd_tlm_server.txt')
     # The maximum number of limits events that are queued. Used when
@@ -179,7 +177,7 @@ module Cosmos
       end
       @json_drb.method_whitelist = @api_whitelist
       begin
-        @json_drb.start_service("localhost", System.ports['CTS_API'], self)
+        @json_drb.start_service(System.listen_hosts['CTS_API'], System.ports['CTS_API'], self)
       rescue Exception
         # Call packet_logging shutdown here to explicitly kill the logging
         # threads since this CTS is not going to launch

--- a/lib/cosmos/tools/cmd_tlm_server/routers.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/routers.rb
@@ -38,6 +38,7 @@ module Cosmos
       router = TcpipServerInterface.new(port, port, 10.0, nil, 'PREIDENTIFIED')
       router.name = router_name
       router.disable_disconnect = true
+      router.set_option('LISTEN_ADDRESS', [System.listen_hosts['CTS_PREIDENTIFIED']])
       router.set_option('AUTO_SYSTEM_META', [true])
       @config.routers[router_name] = router
       @config.interfaces.each do |interface_name, interface|
@@ -57,6 +58,7 @@ module Cosmos
       cmd_router = TcpipServerInterface.new(port, nil, 10.0, nil, 'PREIDENTIFIED')
       cmd_router.name = cmd_router_name
       cmd_router.disable_disconnect = true
+      cmd_router.set_option('LISTEN_ADDRESS', [System.listen_hosts['CTS_CMD_ROUTER']])
       cmd_router.set_option('AUTO_SYSTEM_META', [true])
       @config.routers[cmd_router_name] = cmd_router
       @config.interfaces.each do |interface_name, interface|

--- a/lib/cosmos/tools/replay/replay_server.rb
+++ b/lib/cosmos/tools/replay/replay_server.rb
@@ -34,7 +34,7 @@ module Cosmos
 
       @json_drb.method_whitelist = @api_whitelist
       begin
-        @json_drb.start_service("localhost", System.ports['CTS_API'], self)
+        @json_drb.start_service(System.listen_hosts['CTS_API'], System.ports['CTS_API'], self)
       rescue Exception
         raise FatalError.new("Error starting JsonDRb on port #{System.ports['CTS_API']}.\nPerhaps a Command and Telemetry Server is already running?")
       end

--- a/lib/cosmos/tools/tlm_grapher/tabbed_plots_tool/tabbed_plots_realtime_thread.rb
+++ b/lib/cosmos/tools/tlm_grapher/tabbed_plots_tool/tabbed_plots_realtime_thread.rb
@@ -19,7 +19,7 @@ module Cosmos
 
     # Create a new TabbedPlotsRealtimeThread
     def initialize(tabbed_plots_config, connection_success_callback = nil, connection_failed_callback = nil, connection_lost_callback = nil, fatal_exception_callback = nil)
-      interface = TcpipClientInterface.new('localhost', nil, System.ports['CTS_PREIDENTIFIED'], nil, tabbed_plots_config.cts_timeout, 'PREIDENTIFIED')
+      interface = TcpipClientInterface.new(System.connect_hosts['CTS_PREIDENTIFIED'], nil, System.ports['CTS_PREIDENTIFIED'], nil, tabbed_plots_config.cts_timeout, 'PREIDENTIFIED')
       super(interface)
 
       @queue = Queue.new

--- a/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
+++ b/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
@@ -125,15 +125,14 @@ module Cosmos
           # Start DRb with access control
           @json_drb = JsonDRb.new
           port = System.ports['TLMVIEWER_API']
-          acl = ACL.new(['allow', '127.0.0.1'], ACL::ALLOW_DENY)
-          @json_drb.acl = acl
+          @json_drb.acl = System.acl
           whitelist = [
             'display',
             'clear',
             'clear_all']
           @json_drb.method_whitelist = whitelist
           begin
-            @json_drb.start_service "localhost", port, self
+            @json_drb.start_service System.listen_hosts['TLMVIEWER_API'], port, self
           rescue Exception
             raise FatalError.new("Error starting JsonDRb on port #{port}.\nPerhaps a Telemetry Viewer is already running?")
           end


### PR DESCRIPTION
This will allow tools to connect from external workstations, support some cloud scenarios, and allow the user to only listen on one specific ip on multiple ip systems.