### PR TITLE
Fix to allow get_packet during server boot

### DIFF
--- a/lib/cosmos/script/api_shared.rb
+++ b/lib/cosmos/script/api_shared.rb
@@ -14,25 +14,6 @@ module Cosmos
 
     private
 
-    # Get a packet which was previously subscribed to by
-    # subscribe_packet_data. This method can block waiting for new packets or
-    # not based on the second parameter. It returns a single Cosmos::Packet instance
-    # and will return nil when no more packets are buffered (assuming non_block
-    # is false).
-    # Usage:
-    #   get_packet(id, <true or false to block>)
-    def get_packet(id, non_block = false)
-      packet = nil
-      buffer, target_name, packet_name, rx_sec, rx_usec, rx_count = get_packet_data(id, non_block)
-      if buffer
-        packet = System.telemetry.packet(target_name, packet_name).clone
-        packet.buffer = buffer
-        packet.received_time = Time.at(rx_sec, rx_usec).sys
-        packet.received_count = rx_count
-      end
-      packet
-    end
-
     # Creates a string with the parameters upcased
     def _upcase(target_name, packet_name, item_name)
       "#{target_name.upcase} #{packet_name.upcase} #{item_name.upcase}"

--- a/lib/cosmos/script/api_shared.rb
+++ b/lib/cosmos/script/api_shared.rb
@@ -23,12 +23,12 @@ module Cosmos
     #   get_packet(id, <true or false to block>)
     def get_packet(id, non_block = false)
       packet = nil
-      buffer, target_name, packet_name, received_time, received_count = get_packet_data(id, non_block)
+      buffer, target_name, packet_name, rx_sec, rx_usec, rx_count = get_packet_data(id, non_block)
       if buffer
         packet = System.telemetry.packet(target_name, packet_name).clone
         packet.buffer = buffer
-        packet.received_time = received_time
-        packet.received_count = received_count
+        packet.received_time = Time.at(rx_sec, rx_usec).sys
+        packet.received_count = rx_count
       end
       packet
     end

--- a/lib/cosmos/script/scripting.rb
+++ b/lib/cosmos/script/scripting.rb
@@ -20,6 +20,27 @@ module Cosmos
     # Include additional shared functionality
     include ApiShared
 
+    # Get a packet which was previously subscribed to by
+    # subscribe_packet_data. This method can block waiting for new packets or
+    # not based on the second parameter. It returns a single Cosmos::Packet instance
+    # and will return nil when no more packets are buffered (assuming non_block
+    # is false).
+    # Usage:
+    #   get_packet(id, <true or false to block>)
+    def get_packet(id, non_block = false)
+      packet = nil
+      # The get_packet_data in the Script module (defined in telemetry.rb)
+      # returns a Ruby time after the packet_name. This is different that the API.
+      buffer, target_name, packet_name, time, rx_count = get_packet_data(id, non_block)
+      if buffer
+        packet = System.telemetry.packet(target_name, packet_name).clone
+        packet.buffer = buffer
+        packet.received_time = time
+        packet.received_count = rx_count
+      end
+      packet
+    end
+
     def play_wav_file(wav_filename)
       Cosmos.play_wav_file(wav_filename)
     end
@@ -140,7 +161,5 @@ module Cosmos
     def prompt_combo_box(string, options)
       prompt_message_box(string, options)
     end
-
-  end # module Script
-
-end # module Cosmos
+  end
+end

--- a/lib/cosmos/script/scripting.rb
+++ b/lib/cosmos/script/scripting.rb
@@ -20,27 +20,6 @@ module Cosmos
     # Include additional shared functionality
     include ApiShared
 
-    # Get a packet which was previously subscribed to by
-    # subscribe_packet_data. This method can block waiting for new packets or
-    # not based on the second parameter. It returns a single Cosmos::Packet instance
-    # and will return nil when no more packets are buffered (assuming non_block
-    # is false).
-    # Usage:
-    #   get_packet(id, <true or false to block>)
-    def get_packet(id, non_block = false)
-      packet = nil
-      # The get_packet_data in the Script module (defined in telemetry.rb)
-      # returns a Ruby time after the packet_name. This is different that the API.
-      buffer, target_name, packet_name, time, rx_count = get_packet_data(id, non_block)
-      if buffer
-        packet = System.telemetry.packet(target_name, packet_name).clone
-        packet.buffer = buffer
-        packet.received_time = time
-        packet.received_count = rx_count
-      end
-      packet
-    end
-
     def play_wav_file(wav_filename)
       Cosmos.play_wav_file(wav_filename)
     end

--- a/lib/cosmos/script/telemetry.rb
+++ b/lib/cosmos/script/telemetry.rb
@@ -182,8 +182,14 @@ module Cosmos
       $cmd_tlm_server.unsubscribe_packet_data(id)
     end
 
+    # DEPRECATED for Ruby APIs although still necessary
     def get_packet_data(id, non_block = false)
-      $cmd_tlm_server.get_packet_data(id, non_block)
+      results = $cmd_tlm_server.get_packet_data(id, non_block)
+      if Array === results and results[3] and results[4]
+        results[3] = Time.at(results[3], results[4]).sys
+        results.delete_at(4)
+      end
+      results
     end
   end
 end

--- a/lib/cosmos/script/telemetry.rb
+++ b/lib/cosmos/script/telemetry.rb
@@ -9,7 +9,6 @@
 # attribution addendums as found in the LICENSE.txt
 
 module Cosmos
-
   module Script
     private
 
@@ -19,7 +18,7 @@ module Cosmos
     # or
     #   tlm('target_name packet_name item_name')
     def tlm(*args)
-      return $cmd_tlm_server.tlm(*args)
+      $cmd_tlm_server.tlm(*args)
     end
 
     # Poll for the raw value of a telemetry item
@@ -28,7 +27,7 @@ module Cosmos
     # or
     #   tlm_raw('target_name packet_name item_name')
     def tlm_raw(*args)
-      return $cmd_tlm_server.tlm_raw(*args)
+      $cmd_tlm_server.tlm_raw(*args)
     end
 
     # Poll for the formatted value of a telemetry item
@@ -37,7 +36,7 @@ module Cosmos
     # or
     #   tlm_formatted('target_name packet_name item_name')
     def tlm_formatted(*args)
-      return $cmd_tlm_server.tlm_formatted(*args)
+      $cmd_tlm_server.tlm_formatted(*args)
     end
 
     # Poll for the formatted with units value of a telemetry item
@@ -46,11 +45,11 @@ module Cosmos
     # or
     #   tlm_with_units('target_name packet_name item_name')
     def tlm_with_units(*args)
-      return $cmd_tlm_server.tlm_with_units(*args)
+      $cmd_tlm_server.tlm_with_units(*args)
     end
 
     def tlm_variable(*args)
-      return $cmd_tlm_server.tlm_variable(*args)
+      $cmd_tlm_server.tlm_variable(*args)
     end
 
     # Set a telemetry point to a given value. Note this will be over written in
@@ -60,7 +59,7 @@ module Cosmos
     # or
     #   set_tlm("target_name packet_name item_name = value")
     def set_tlm(*args)
-      return $cmd_tlm_server.set_tlm(*args)
+      $cmd_tlm_server.set_tlm(*args)
     end
 
     # Set the raw value of a telemetry point to a given value. Note this will
@@ -70,7 +69,7 @@ module Cosmos
     # or
     #   set_tlm_raw("target_name packet_name item_name = value")
     def set_tlm_raw(*args)
-      return $cmd_tlm_server.set_tlm_raw(*args)
+      $cmd_tlm_server.set_tlm_raw(*args)
     end
 
     # Injects a packet into the system as if it was received from an interface
@@ -83,7 +82,7 @@ module Cosmos
     # @param send_packet_log_writers[Boolean] Whether or not to send to the packet log writers for the target's interface
     # @param create_new_logs[Boolean] Whether or not to create new log files before writing this packet to logs
     def inject_tlm(target_name, packet_name, item_hash = nil, value_type = :CONVERTED, send_routers = true, send_packet_log_writers = true, create_new_logs = false)
-      return $cmd_tlm_server.inject_tlm(target_name, packet_name, item_hash, value_type, send_routers, send_packet_log_writers, create_new_logs)
+      $cmd_tlm_server.inject_tlm(target_name, packet_name, item_hash, value_type, send_routers, send_packet_log_writers, create_new_logs)
     end
 
     # Permanently set the converted value of a telemetry point to a given value
@@ -92,7 +91,7 @@ module Cosmos
     # or
     #   override_tlm("target_name packet_name item_name = value")
     def override_tlm(*args)
-      return $cmd_tlm_server.override_tlm(*args)
+      $cmd_tlm_server.override_tlm(*args)
     end
 
     # Permanently set the raw value of a telemetry point to a given value
@@ -101,7 +100,7 @@ module Cosmos
     # or
     #   override_tlm_raw("target_name packet_name item_name = value")
     def override_tlm_raw(*args)
-      return $cmd_tlm_server.override_tlm_raw(*args)
+      $cmd_tlm_server.override_tlm_raw(*args)
     end
 
     # Clear an override of a telemetry point
@@ -110,7 +109,7 @@ module Cosmos
     # or
     #   normalize_tlm("target_name packet_name item_name")
     def normalize_tlm(*args)
-      return $cmd_tlm_server.normalize_tlm(*args)
+      $cmd_tlm_server.normalize_tlm(*args)
     end
 
     # Gets all the values from the given packet returned in a two dimensional
@@ -144,18 +143,18 @@ module Cosmos
     # Gets the packets for a given target name. Returns an array of arrays
     # consisting of packet names and packet descriptions.
     def get_tlm_list(target_name)
-      return $cmd_tlm_server.get_tlm_list(target_name)
+      $cmd_tlm_server.get_tlm_list(target_name)
     end
 
     # Gets all the telemetry mnemonics for a given target and packet. Returns an
     # array of arrays consisting of item names, item states, and item descriptions.
     def get_tlm_item_list(target_name, packet_name)
-      return $cmd_tlm_server.get_tlm_item_list(target_name, packet_name)
+      $cmd_tlm_server.get_tlm_item_list(target_name, packet_name)
     end
 
     # Gets the list of all defined targets.
     def get_target_list
-      return $cmd_tlm_server.get_target_list
+      $cmd_tlm_server.get_target_list
     end
 
     def get_tlm_details(items)
@@ -164,7 +163,7 @@ module Cosmos
 
     # Returns the buffer from the telemetry packet.
     def get_tlm_buffer(target_name, packet_name)
-      return $cmd_tlm_server.get_tlm_buffer(target_name, packet_name)
+      $cmd_tlm_server.get_tlm_buffer(target_name, packet_name)
     end
 
     # Subscribe to one or more telemetry packets. The queue ID is returned for
@@ -172,8 +171,7 @@ module Cosmos
     # Usage:
     #   id = subscribe_packet_data([[target_name,packet_name], ...], <queue_size>)
     def subscribe_packet_data(packets, queue_size = CmdTlmServer::DEFAULT_PACKET_DATA_QUEUE_SIZE)
-      result = $cmd_tlm_server.subscribe_packet_data(packets, queue_size)
-      result
+      $cmd_tlm_server.subscribe_packet_data(packets, queue_size)
     end
 
     # Unsubscribe to telemetry packets. Pass the queue ID which was returned by
@@ -181,20 +179,11 @@ module Cosmos
     # Usage:
     #   unsubscribe_packet_data(id)
     def unsubscribe_packet_data(id)
-      result = $cmd_tlm_server.unsubscribe_packet_data(id)
-      result
+      $cmd_tlm_server.unsubscribe_packet_data(id)
     end
 
-    # DEPRECATED
     def get_packet_data(id, non_block = false)
-      results = $cmd_tlm_server.get_packet_data(id, non_block)
-      if Array === results and results[3] and results[4]
-        results[3] = Time.at(results[3], results[4]).sys
-        results.delete_at(4)
-      end
-      results
+      $cmd_tlm_server.get_packet_data(id, non_block)
     end
-
   end
 end
-

--- a/lib/cosmos/script/telemetry.rb
+++ b/lib/cosmos/script/telemetry.rb
@@ -191,5 +191,26 @@ module Cosmos
       end
       results
     end
+
+    # Get a packet which was previously subscribed to by
+    # subscribe_packet_data. This method can block waiting for new packets or
+    # not based on the second parameter. It returns a single Cosmos::Packet instance
+    # and will return nil when no more packets are buffered (assuming non_block
+    # is false).
+    # Usage:
+    #   get_packet(id, <true or false to block>)
+    def get_packet(id, non_block = false)
+      packet = nil
+      # The get_packet_data above returns a Ruby time after the packet_name.
+      # This is different from the API.s
+      buffer, target_name, packet_name, time, rx_count = get_packet_data(id, non_block)
+      if buffer
+        packet = System.telemetry.packet(target_name, packet_name).clone
+        packet.buffer = buffer
+        packet.received_time = time
+        packet.received_count = rx_count
+      end
+      packet
+    end
   end
 end

--- a/lib/cosmos/tools/cmd_tlm_server/api.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/api.rb
@@ -947,6 +947,27 @@ module Cosmos
       CmdTlmServer.get_packet_data(id, non_block)
     end
 
+    # Get a packet which was previously subscribed to by
+    # subscribe_packet_data. This method can block waiting for new packets or
+    # not based on the second parameter. It returns a single Cosmos::Packet instance
+    # and will return nil when no more packets are buffered (assuming non_block
+    # is false).
+    # Usage:
+    #   get_packet(id, <true or false to block>)
+    def get_packet(id, non_block = false)
+      packet = nil
+      # The get_packet_data in the CmdTlmServer returns the number of seconds
+      # followed by microseconds after the packet_name. This is different that the Script API.
+      buffer, target_name, packet_name, rx_sec, rx_usec, rx_count = get_packet_data(id, non_block)
+      if buffer
+        packet = System.telemetry.packet(target_name, packet_name).clone
+        packet.buffer = buffer
+        packet.received_time = Time.at(rx_sec, rx_usec).sys
+        packet.received_count = rx_count
+      end
+      packet
+    end
+
     #
     # Methods for scripting
     #

--- a/lib/cosmos/tools/cmd_tlm_server/api.rb
+++ b/lib/cosmos/tools/cmd_tlm_server/api.rb
@@ -532,10 +532,12 @@ module Cosmos
       packet = cvt_packet.clone
       packet.received_time = received_time
 
-      # Update the packet with item_hash
-      value_type = value_type.to_s.intern
-      item_hash.each do |item_name, item_value|
-        packet.write(item_name, item_value, value_type)
+      if item_hash
+        # Update the packet with item_hash
+        value_type = value_type.to_s.intern
+        item_hash.each do |item_name, item_value|
+          packet.write(item_name, item_value, value_type)
+        end
       end
 
       # Update current value table

--- a/spec/script/telemetry_spec.rb
+++ b/spec/script/telemetry_spec.rb
@@ -161,12 +161,14 @@ module Cosmos
         unsubscribe_packet_data(id)
       end
 
-      it "subscribes and get limits events" do
-        id = subscribe_packet_data([["INST","HEALTH_STATUS"]])
-        CmdTlmServer.instance.post_packet(System.telemetry.packet("INST","HEALTH_STATUS"))
-        packet = get_packet(id, true)
-        expect(packet.target_name).to eql "INST"
-        expect(packet.packet_name).to eql "HEALTH_STATUS"
+      it "subscribes and gets packets" do
+        id = subscribe_packet_data([["SYSTEM","META"]])
+        inject_tlm("SYSTEM", "META")
+        packet = get_packet(id)
+        expect(packet.target_name).to eql "SYSTEM"
+        expect(packet.packet_name).to eql "META"
+        expect(packet.received_time).to be_within(0.1).of Time.now
+        expect(packet.received_count).to eql 1
         unsubscribe_packet_data(id)
       end
     end

--- a/spec/script/telemetry_spec.rb
+++ b/spec/script/telemetry_spec.rb
@@ -167,7 +167,7 @@ module Cosmos
         packet = get_packet(id)
         expect(packet.target_name).to eql "SYSTEM"
         expect(packet.packet_name).to eql "META"
-        expect(packet.received_time).to be_within(0.1).of Time.now
+        expect(packet.received_time).to be_within(1).of Time.now
         expect(packet.received_count).to eql 1
         unsubscribe_packet_data(id)
       end


### PR DESCRIPTION
This one was tricky. My background task was trying to call get_packet but the telemetry.rb get_packet_data method wasn't being called so that little Time.at code wasn't getting called. I removed that to make get_packet_data just call the $cmd_tlm_server version with no extras and put the Time.at code in the api_shared get_packet code.

Did the telemetry.rb code not get called because I'm part of the server as a background task?

closes #540 