### PR TITLE
Tune HTTP JSON DRb Implementation

### DIFF
--- a/lib/cosmos/io/json_drb.rb
+++ b/lib/cosmos/io/json_drb.rb
@@ -113,7 +113,7 @@ module Cosmos
     # @param object [Object] The object to send the DRb requests to. This
     #   object must either include the Cosmos::Script module or be the
     #   CmdTlmServer.
-    def start_service(hostname = nil, port = nil, object = nil)
+    def start_service(hostname = nil, port = nil, object = nil, max_threads = 1000)
       server_started = false
       @server_mutex.synchronize do
         server_started = true if @server
@@ -132,6 +132,8 @@ module Cosmos
               :Host   => hostname,
               :Port   => port,
               :Silent => true,
+              :Verbose => false,
+              :Threads => "0:#{max_threads}",
             }
 
             # The run call will block until the server is stopped.

--- a/lib/cosmos/io/json_drb_object.rb
+++ b/lib/cosmos/io/json_drb_object.rb
@@ -106,7 +106,7 @@ module Cosmos
         if !@http
           @http = HTTPClient.new
           @http.connect_timeout = @connect_timeout
-          @http.receive_timeout = @connect_timeout
+          @http.receive_timeout = nil # Allow long polling
         end
       rescue => e
         raise DRb::DRbConnError, e.message
@@ -123,7 +123,7 @@ module Cosmos
         STDOUT.puts request_data if JsonDRb.debug?
         @request_in_progress = true
         headers = {'Content-Type' => 'application/json-rpc'}
-        res = @http.post(@uri, 
+        res = @http.post(@uri,
                          :body   => request_data,
                          :header => headers)
         response_data = res.body
@@ -140,7 +140,7 @@ module Cosmos
 
     def handle_response(response_data)
       # The code below will always either raise or return breaking out of the loop
-      if response_data
+      if response_data and response_data.to_s.length > 0
         response = JsonRpcResponse.from_json(response_data)
         if JsonRpcErrorResponse === response
           if response.error.data


### PR DESCRIPTION
Several fixes here:

1. Removed the receive timeout - It was set at 1 second which was causing long polling problems.  The old implementation didn't have timeout and really puts the responsibility on the cmd/tlm server to behave correctly which is fine.

2. Increased the max threads for Puma to 1000 by default.   I was not able to run more than two tools at the same time before.

3. Handled the different behavior when closing the server of getting an empty response instead of a nil response.

Seems to work really well now!