### PR TITLE
Add Search Bar to CmdSender

### DIFF
--- a/lib/cosmos/packets/commands.rb
+++ b/lib/cosmos/packets/commands.rb
@@ -261,6 +261,28 @@ module Cosmos
       end
     end
 
+    # Returns an array with a "TARGET_NAME PACKET_NAME" string for every command in the system (PACKET_NAME == command name)
+    def all_item_strings(include_hidden = false, splash = nil)
+      strings = []
+      tnames = target_names()
+      total = tnames.length.to_f
+      tnames.each_with_index do |target_name, index|
+        if splash
+          splash.message = "Processing #{target_name} command"
+          splash.progress = index / total
+        end
+
+        ignored_items = System.targets[target_name].ignored_items
+
+        packets(target_name).each do |command_name, packet|
+          # We don't audit against hidden or disabled packets/commands
+          next if !include_hidden and (packet.hidden || packet.disabled)
+          strings << "#{target_name} #{command_name}"
+        end
+      end
+      strings
+    end
+
     def all
       @config.commands
     end

--- a/lib/cosmos/packets/commands.rb
+++ b/lib/cosmos/packets/commands.rb
@@ -262,7 +262,7 @@ module Cosmos
     end
 
     # Returns an array with a "TARGET_NAME PACKET_NAME" string for every command in the system (PACKET_NAME == command name)
-    def all_item_strings(include_hidden = false, splash = nil)
+    def all_packet_strings(include_hidden = false, splash = nil)
       strings = []
       tnames = target_names()
       total = tnames.length.to_f

--- a/lib/cosmos/tools/cmd_sender/cmd_sender.rb
+++ b/lib/cosmos/tools/cmd_sender/cmd_sender.rb
@@ -112,7 +112,7 @@ module Cosmos
           update_cmd_params()
 
           # Handle searching entries
-          @search_box.completion_list = System.commands.all_item_strings(true, splash)
+          @search_box.completion_list = System.commands.all_packet_strings(true, splash)
           @search_box.callback = lambda do |cmd|
             split_cmd = cmd.split(" ")
             if split_cmd.length == 2

--- a/lib/cosmos/tools/cmd_sender/cmd_sender.rb
+++ b/lib/cosmos/tools/cmd_sender/cmd_sender.rb
@@ -19,6 +19,7 @@ Cosmos.catch_fatal_exception do
   require 'cosmos/gui/dialogs/cmd_details_dialog'
   require 'cosmos/tools/cmd_sender/cmd_sender_text_edit'
   require 'cosmos/tools/cmd_sender/cmd_param_table_item_delegate'
+  require 'cosmos/gui/widgets/full_text_search_line_edit'
 end
 
 module Cosmos
@@ -109,6 +110,21 @@ module Cosmos
           update_commands()
           @cmd_select.setCurrentText(options.packet[1]) if options.packet
           update_cmd_params()
+
+          # Handle searching entries
+          @search_box.completion_list = System.commands.all_item_strings(true, splash)
+          @search_box.callback = lambda do |cmd|
+            split_cmd = cmd.split(" ")
+            if split_cmd.length == 2
+              target_name = split_cmd[0].upcase
+              @target_select.setCurrentText(target_name)
+              update_commands()
+              command_name = split_cmd[1]
+              @cmd_select.setCurrentText(command_name)
+              update_cmd_params()
+            end
+          end
+
         end
 
         # Unconfigure CosmosConfig to interact with splash screen
@@ -219,6 +235,10 @@ module Cosmos
       # Set the size constraint to always respect the minimum sizes of the child widgets
       # If this is not set then when we refresh the command parameters they'll all be squished
       top_layout.setSizeConstraint(Qt::Layout::SetMinimumSize)
+
+      # Mnemonic Search Box
+      @search_box = FullTextSearchLineEdit.new(self)
+      top_layout.addWidget(@search_box)
 
       # Set the target combobox selection
       @target_select = Qt::ComboBox.new


### PR DESCRIPTION
The purpose of this pull request is to add a search feature to CmdSender similar to that of PacketViewer.

The differ slightly, because the TLM side is searching by Target/Packet/Item, and CMD side is searching by only Target/Packet, but the code is very similar, and the functionality should appear the same to the user.

I didn't find any tests associated with the PacketViewer functionality, so I wasn't sure if anything needed to be updated for this request test-wise.