### PR TITLE
Classification Bar

### DIFF
--- a/demo/config/system/system.txt
+++ b/demo/config/system/system.txt
@@ -52,10 +52,10 @@ ADD_MD5_FILE lib/user_version.rb
 
 # Banner examples
 # Create a banner using an existing COSMOS color (Cosmos::GREEN in this case)
-# CLASSIFICATION demo-banner-title green
+# CLASSIFICATION UNCLASSIFIED green
 
 # Create a banner using a Qt::Color that doesn't exist in COSMOS
-# CLASSIFICATION demo-banner-title teal
+# CLASSIFICATION "Ball Aerospace COSMOS" teal
 
 # Create a banner using a RGB color values
-# CLASSIFICATION demo-banner-title 255 114 0
+# CLASSIFICATION Secret 255 114 0

--- a/demo/config/system/system.txt
+++ b/demo/config/system/system.txt
@@ -49,3 +49,13 @@ ENABLE_SOUND
 META_INIT config/data/meta_init.txt
 
 ADD_MD5_FILE lib/user_version.rb
+
+# Banner examples
+# Create a banner using an existing COSMOS color (Cosmos::GREEN in this case)
+# CLASSIFICATION demo-banner-title green
+
+# Create a banner using a Qt::Color that doesn't exist in COSMOS
+# CLASSIFICATION demo-banner-title teal
+
+# Create a banner using a RGB color values
+# CLASSIFICATION demo-banner-title 255 114 0

--- a/lib/cosmos/gui/qt_tool.rb
+++ b/lib/cosmos/gui/qt_tool.rb
@@ -18,6 +18,16 @@ require 'ostruct'
 require 'optparse'
 
 module Cosmos
+
+  # This is the first instance where classification headers are needed, so set up the constants for
+  #   the classification headers.
+  # Any number of color/text combinations can be added here for whatever the need is
+  CLASSIFICATION_OPTIONS = {
+    'unclassified' => {'color' => 'green',  'text' => 'UNCLASSIFIED'}
+  }
+  CURRENT_CLASSIFICATION = 'unclassified'
+  CLASSIFICATION = CLASSIFICATION_OPTIONS[CURRENT_CLASSIFICATION]
+
   # Base class of all COSMOS GUI Tools based on QT. It creates the help menu
   # which contains the About menu option. It provides configuration to all
   # tools to remember both the application window location and size across
@@ -65,6 +75,45 @@ module Cosmos
         @options.config_file = config_path(@options.config_file, ".txt", tool_name)
         @options.stylesheet = config_path(@options.stylesheet, ".css", tool_name)
       end
+
+      #
+      # We want to add a classification bar to every Tool that gets launched. This is intentionally
+      #   hard coded here so a configuration file cannot make this not display
+      # There is a corresponding bar that gets added to every Screen (/lib/cosmos/tools/tlm_viewer/screen.rb)
+      #
+
+      unless CLASSIFICATION.nil?
+        # Create a classification toolbar
+        classification_toolbar = Qt::ToolBar.new
+        # Disable right clicking on the bar (prevents it from being hidden unintentionally)
+        classification_toolbar.setContextMenuPolicy(Qt::PreventContextMenu)
+        # Freeze the bar at the top
+        classification_toolbar.setFloatable(false)
+        classification_toolbar.setMovable(false)
+        # Specify minimum sizes and set the style
+        classification_toolbar.minimumHeight = 20
+        classification_toolbar.maximumHeight = 20
+        classification_toolbar.setStyleSheet("background:#{CLASSIFICATION['color']};color:white;text-align:center;border:none;")
+
+        # Create a frame that will hold a horizontal layout
+        label_frame = Qt::Frame.new
+        label_layout = Qt::HBoxLayout.new(label_frame)
+        label_layout.setContentsMargins(0,1,0,0) # Centers the text nicely inside the horizontal layout
+
+        # Create a label of the classification and add it the horizontal layout
+        label = Qt::Label.new("#{CLASSIFICATION['text']}")
+        label.setStyleSheet("margin:0px;")
+
+        # Add stretchers on either side so it is always in the middle and looks nice
+        label_layout.addStretch(1)
+        label_layout.addWidget(label)
+        label_layout.addStretch(1)
+
+        # Add the frame to the main toolbar, then add the toolbar to the MainWindow
+        classification_toolbar.addWidget(label_frame)
+        self.addToolBar(classification_toolbar)
+      end
+
     end
 
     # Creates a path to a configuration file. If the file is given it is

--- a/lib/cosmos/gui/qt_tool.rb
+++ b/lib/cosmos/gui/qt_tool.rb
@@ -96,7 +96,7 @@ module Cosmos
         label_layout.setContentsMargins(0,1,0,0) # Centers the text nicely inside the horizontal layout
 
         # Create a label of the classification and add it the horizontal layout
-        label = Qt::Label.new("#{classification_banner['display_text'].upcase}")
+        label = Qt::Label.new("#{classification_banner['display_text']}")
         label.setStyleSheet("margin:0px;")
 
         # Add stretchers on either side so it is always in the middle and looks nice

--- a/lib/cosmos/gui/qt_tool.rb
+++ b/lib/cosmos/gui/qt_tool.rb
@@ -67,12 +67,9 @@ module Cosmos
         @options.stylesheet = config_path(@options.stylesheet, ".css", tool_name)
       end
 
-      #
-      # We want to add a classification bar to every Tool that gets launched. This is intentionally
-      #   hard coded here so a configuration file cannot make this not display
-      # There is a corresponding bar that gets added to every Screen (/lib/cosmos/tools/tlm_viewer/screen.rb)
-      #
-
+      # Add a classification banner to every Tool that gets launched if the system configuration
+      #   called for one
+      # There is a corresponding banner that gets added to every Screen (/lib/cosmos/tools/tlm_viewer/screen.rb)
       classification_banner = System.instance.classificiation_banner
       unless classification_banner.nil?
         # Get the RGB color information from the classification_banner

--- a/lib/cosmos/gui/qt_tool.rb
+++ b/lib/cosmos/gui/qt_tool.rb
@@ -19,15 +19,6 @@ require 'optparse'
 
 module Cosmos
 
-  # This is the first instance where classification headers are needed, so set up the constants for
-  #   the classification headers.
-  # Any number of color/text combinations can be added here for whatever the need is
-  CLASSIFICATION_OPTIONS = {
-    'unclassified' => {'color' => 'green',  'text' => 'UNCLASSIFIED'}
-  }
-  CURRENT_CLASSIFICATION = 'unclassified'
-  CLASSIFICATION = CLASSIFICATION_OPTIONS[CURRENT_CLASSIFICATION]
-
   # Base class of all COSMOS GUI Tools based on QT. It creates the help menu
   # which contains the About menu option. It provides configuration to all
   # tools to remember both the application window location and size across

--- a/lib/cosmos/gui/qt_tool.rb
+++ b/lib/cosmos/gui/qt_tool.rb
@@ -82,7 +82,14 @@ module Cosmos
       # There is a corresponding bar that gets added to every Screen (/lib/cosmos/tools/tlm_viewer/screen.rb)
       #
 
-      unless CLASSIFICATION.nil?
+      classification_banner = System.instance.classificiation_banner
+      unless classification_banner.nil?
+        # Get the RGB color information from the classification_banner
+        color_red   = classification_banner['color'].red
+        color_green = classification_banner['color'].green
+        color_blue  = classification_banner['color'].blue
+        color_rgb   = "#{color_red},#{color_green},#{color_blue}"
+
         # Create a classification toolbar
         classification_toolbar = Qt::ToolBar.new
         # Disable right clicking on the bar (prevents it from being hidden unintentionally)
@@ -90,10 +97,10 @@ module Cosmos
         # Freeze the bar at the top
         classification_toolbar.setFloatable(false)
         classification_toolbar.setMovable(false)
-        # Specify minimum sizes and set the style
+        # Specify sizes and set the style (background = background color, color = text color)
         classification_toolbar.minimumHeight = 20
         classification_toolbar.maximumHeight = 20
-        classification_toolbar.setStyleSheet("background:#{CLASSIFICATION['color']};color:white;text-align:center;border:none;")
+        classification_toolbar.setStyleSheet("background:rgb(#{color_rgb});color:white;text-align:center;border:none;")
 
         # Create a frame that will hold a horizontal layout
         label_frame = Qt::Frame.new
@@ -101,7 +108,7 @@ module Cosmos
         label_layout.setContentsMargins(0,1,0,0) # Centers the text nicely inside the horizontal layout
 
         # Create a label of the classification and add it the horizontal layout
-        label = Qt::Label.new("#{CLASSIFICATION['text']}")
+        label = Qt::Label.new("#{classification_banner['display_text'].upcase}")
         label.setStyleSheet("margin:0px;")
 
         # Add stretchers on either side so it is always in the middle and looks nice

--- a/lib/cosmos/system/system.rb
+++ b/lib/cosmos/system/system.rb
@@ -71,6 +71,8 @@ module Cosmos
     #   calculation in addition to the cmd/tlm definition files that are
     #   automatically included
     instance_attr_reader :additional_md5_files
+    # @return [Hash<String,String>] Hash of the text/color to use for the classificaiton banner
+    instance_attr_reader :classificiation_banner
 
     # Known COSMOS ports
     KNOWN_PORTS = ['CTS_API', 'TLMVIEWER_API', 'CTS_PREIDENTIFIED', 'CTS_CMD_ROUTER', 'REPLAY_API', 'REPLAY_PREIDENTIFIED', 'REPLAY_CMD_ROUTER', 'DART_STREAM', 'DART_DECOM']
@@ -336,6 +338,25 @@ module Cosmos
             else
               raise "Missing expected file: #{parameters[0]}"
             end
+
+          when 'CLASSIFICATION'
+            parser.verify_num_parameters(2, 4, "#{keyword} <Display_Text> <Color Name|Red> <Green> <Blue>")
+            # Determine if the COSMOS color already exists, otherwise create a new one
+            if Cosmos.constants.include? parameters[1].upcase.to_sym
+              # We were given a named color that already exists in COSMOS
+              color = eval("Cosmos::#{parameters[1].upcase}")
+            else
+              if parameters.length < 4
+                # We were given a named color, but it didn't exist in COSMOS already
+                color = Cosmos::getColor(parameters[1].upcase)
+              else
+                # We were given RGB values
+                color = Cosmos::getColor(parameters[1], parameters[2], parameters[3])
+              end
+            end
+
+            @classificiation_banner = {'display_text' => parameters[0],
+                                       'color'        => color}
 
           else
             # blank lines will have a nil keyword and should not raise an exception

--- a/lib/cosmos/tools/cmd_sender/cmd_sender.rb
+++ b/lib/cosmos/tools/cmd_sender/cmd_sender.rb
@@ -10,16 +10,16 @@
 
 require 'cosmos'
 Cosmos.catch_fatal_exception do
-  require 'cosmos/script'
   require 'cosmos/gui/qt_tool'
-  require 'cosmos/config/config_parser'
   require 'cosmos/gui/text/completion'
   require 'cosmos/gui/utilities/script_module_gui'
   require 'cosmos/gui/dialogs/splash'
   require 'cosmos/gui/dialogs/cmd_details_dialog'
+  require 'cosmos/gui/widgets/full_text_search_line_edit'
   require 'cosmos/tools/cmd_sender/cmd_sender_text_edit'
   require 'cosmos/tools/cmd_sender/cmd_param_table_item_delegate'
-  require 'cosmos/gui/widgets/full_text_search_line_edit'
+  require 'cosmos/config/config_parser'
+  require 'cosmos/script'
 end
 
 module Cosmos

--- a/lib/cosmos/tools/cmd_sequence/cmd_sequence.rb
+++ b/lib/cosmos/tools/cmd_sequence/cmd_sequence.rb
@@ -11,14 +11,14 @@
 require 'time'
 require 'cosmos'
 Cosmos.catch_fatal_exception do
-  require 'cosmos/script'
-  require 'cosmos/config/config_parser'
   require 'cosmos/gui/qt_tool'
   require 'cosmos/gui/utilities/script_module_gui'
   require 'cosmos/gui/dialogs/splash'
   require 'cosmos/gui/widgets/realtime_button_bar'
   require 'cosmos/gui/choosers/file_chooser'
+  require 'cosmos/config/config_parser'
   require 'cosmos/tools/cmd_sequence/sequence_list'
+  require 'cosmos/script'
 end
 
 module Cosmos

--- a/lib/cosmos/tools/config_editor/config_editor.rb
+++ b/lib/cosmos/tools/config_editor/config_editor.rb
@@ -11,9 +11,9 @@
 require 'cosmos'
 Cosmos.catch_fatal_exception do
   require 'cosmos/gui/qt_tool'
-  require 'cosmos/tools/config_editor/config_editor_frame'
   require 'cosmos/gui/dialogs/progress_dialog'
   require 'cosmos/gui/dialogs/scroll_text_dialog'
+  require 'cosmos/tools/config_editor/config_editor_frame'
 end
 
 module Cosmos

--- a/lib/cosmos/tools/data_viewer/data_viewer.rb
+++ b/lib/cosmos/tools/data_viewer/data_viewer.rb
@@ -10,8 +10,6 @@
 
 require 'cosmos'
 Cosmos.catch_fatal_exception do
-  require 'cosmos/script'
-  require 'cosmos/config/config_parser'
   require 'cosmos/gui/qt_tool'
   require 'cosmos/gui/dialogs/splash'
   require 'cosmos/gui/dialogs/progress_dialog'
@@ -22,6 +20,8 @@ Cosmos.catch_fatal_exception do
   require 'cosmos/gui/widgets/realtime_button_bar'
   require 'cosmos/tools/data_viewer/data_viewer_component'
   require 'cosmos/tools/data_viewer/dump_component'
+  require 'cosmos/config/config_parser'
+  require 'cosmos/script'
 end
 
 module Cosmos
@@ -537,7 +537,7 @@ module Cosmos
               @interface.disconnect
               request_packet = Cosmos::Packet.new('DART', 'DART')
               request_packet.define_item('REQUEST', 0, 0, :BLOCK)
-              
+
               @time_start ||= Time.utc(1970, 1, 1)
               @time_end ||= Time.now
               @time_delta = @time_end - @time_start
@@ -550,7 +550,7 @@ module Cosmos
               request['packets'] = @packets
               request['meta_filters'] = @meta_filters unless @meta_filters.empty?
               request_packet.write('REQUEST', JSON.dump(request))
-            
+
               progress_dialog.append_text("Connecting to DART Database...")
               @interface.connect
               progress_dialog.append_text("Sending DART Database Query...")
@@ -570,7 +570,7 @@ module Cosmos
 
                 # Switch to correct configuration from SYSTEM META when needed
                 if packet.target_name == 'SYSTEM'.freeze and packet.packet_name == 'META'.freeze
-                  meta_packet = System.telemetry.update!('SYSTEM', 'META', packet.buffer)                             
+                  meta_packet = System.telemetry.update!('SYSTEM', 'META', packet.buffer)
                   Cosmos::System.load_configuration(meta_packet.read('CONFIG'))
                 elsif first
                   first = false
@@ -600,7 +600,7 @@ module Cosmos
               progress_dialog.append_text("Canceled!") if @cancel_progress
               progress_dialog.complete
             end
-          end            
+          end
         rescue => error
           Qt::MessageBox.critical(self, 'Error!', "Error Querying DART Database\n#{error.formatted}")
         ensure

--- a/lib/cosmos/tools/packet_viewer/packet_viewer.rb
+++ b/lib/cosmos/tools/packet_viewer/packet_viewer.rb
@@ -10,7 +10,6 @@
 
 require 'cosmos'
 Cosmos.catch_fatal_exception do
-  require 'cosmos/script'
   require 'cosmos/gui/qt_tool'
   require 'cosmos/gui/dialogs/tlm_details_dialog'
   require 'cosmos/gui/dialogs/tlm_edit_dialog'
@@ -18,6 +17,7 @@ Cosmos.catch_fatal_exception do
   require 'cosmos/gui/dialogs/exception_dialog'
   require 'cosmos/gui/dialogs/splash'
   require 'cosmos/gui/widgets/full_text_search_line_edit'
+  require 'cosmos/script'
 end
 
 module Cosmos

--- a/lib/cosmos/tools/table_manager/table_manager.rb
+++ b/lib/cosmos/tools/table_manager/table_manager.rb
@@ -12,9 +12,9 @@ require 'cosmos'
 Cosmos.catch_fatal_exception do
   require 'cosmos/gui/qt_tool'
   require 'cosmos/gui/dialogs/progress_dialog'
+  require 'cosmos/gui/dialogs/tlm_details_dialog'
   require 'cosmos/tools/table_manager/table_config'
   require 'cosmos/tools/table_manager/table_manager_core'
-  require 'cosmos/gui/dialogs/tlm_details_dialog'
 end
 
 class Qt::ComboBox

--- a/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
+++ b/lib/cosmos/tools/tlm_extractor/tlm_extractor.rb
@@ -10,8 +10,6 @@
 
 require 'cosmos'
 Cosmos.catch_fatal_exception do
-  require 'cosmos/tools/tlm_extractor/tlm_extractor_processor'
-  require 'cosmos/tools/tlm_extractor/text_item_chooser'
   require 'cosmos/gui/qt_tool'
   require 'cosmos/gui/choosers/telemetry_chooser'
   require 'cosmos/gui/choosers/float_chooser'
@@ -21,6 +19,8 @@ Cosmos.catch_fatal_exception do
   require 'cosmos/gui/dialogs/progress_dialog'
   require 'cosmos/gui/widgets/full_text_search_line_edit'
   require 'cosmos/gui/utilities/analyze_log'
+  require 'cosmos/tools/tlm_extractor/tlm_extractor_processor'
+  require 'cosmos/tools/tlm_extractor/text_item_chooser'
 end
 
 module Cosmos
@@ -402,7 +402,7 @@ module Cosmos
       @data_source_layout.addWidget(label)
       @log_file_radio = Qt::RadioButton.new("Log File", self)
       @log_file_radio.setChecked(true)
-      @log_file_radio.connect(SIGNAL('clicked()')) do 
+      @log_file_radio.connect(SIGNAL('clicked()')) do
         @packet_log_frame.show_log_fields(true)
         @packet_log_frame.output_filename = ""
         @dart_meta_frame.hide
@@ -410,12 +410,12 @@ module Cosmos
       end
       @data_source_layout.addWidget(@log_file_radio)
       @dart_radio = Qt::RadioButton.new("DART Database", self)
-      @dart_radio.connect(SIGNAL('clicked()')) do 
+      @dart_radio.connect(SIGNAL('clicked()')) do
         @packet_log_frame.show_log_fields(false)
         @packet_log_frame.output_filename = ""
         @dart_meta_frame.show
         @resize_timer.start(100)
-      end      
+      end
       @data_source_layout.addWidget(@dart_radio)
       @data_source_layout.addStretch()
       @top_layout.addLayout(@data_source_layout)
@@ -609,7 +609,7 @@ module Cosmos
       clear_config_item_list()
       @tlm_extractor_config.items.each do |item_type, target_name_or_column_name, packet_name_or_text, item_name, value_type, dart_reduction, dart_reduced_type|
         if item_type == 'ITEM'
-          if dart_reduction == :NONE 
+          if dart_reduction == :NONE
             if value_type == :CONVERTED
               @config_item_list.addItem("#{item_type} #{target_name_or_column_name} #{packet_name_or_text} #{item_name}")
             else

--- a/lib/cosmos/tools/tlm_viewer/screen.rb
+++ b/lib/cosmos/tools/tlm_viewer/screen.rb
@@ -237,10 +237,17 @@ module Cosmos
       #
       # We want to add a classification bar to every Tool that gets launched. This is intentionally
       #   hard coded here so a configuration file cannot make this not display
-      # There is a corresponding bar that gets added to every Screen (/lib/cosmos/tools/tlm_viewer/screen.rb)
+      # There is a corresponding bar that gets added to every Tool (/lib/cosmos/gui/qt_tool.rb)
       #
 
-      unless CLASSIFICATION.nil?
+      classification_banner = System.instance.classificiation_banner
+      unless classification_banner.nil?
+        # Get the RGB color information from the classification_banner
+        color_red   = classification_banner['color'].red
+        color_green = classification_banner['color'].green
+        color_blue  = classification_banner['color'].blue
+        color_rgb   = "#{color_red},#{color_green},#{color_blue}"
+
         # Create a classification toolbar
         classification_toolbar = Qt::ToolBar.new
         # Disable right clicking on the bar (prevents it from being hidden unintentionally)
@@ -248,10 +255,10 @@ module Cosmos
         # Freeze the bar at the top
         classification_toolbar.setFloatable(false)
         classification_toolbar.setMovable(false)
-        # Specify minimum sizes and set the style
+        # Specify sizes and set the style (background = background color, color = text color)
         classification_toolbar.minimumHeight = 20
         classification_toolbar.maximumHeight = 20
-        classification_toolbar.setStyleSheet("background:#{CLASSIFICATION['color']};color:white;text-align:center;border:none;")
+        classification_toolbar.setStyleSheet("background:rgb(#{color_rgb});color:white;text-align:center;border:none;")
 
         # Create a frame that will hold a horizontal layout
         label_frame = Qt::Frame.new
@@ -259,7 +266,7 @@ module Cosmos
         label_layout.setContentsMargins(0,1,0,0) # Centers the text nicely inside the horizontal layout
 
         # Create a label of the classification and add it the horizontal layout
-        label = Qt::Label.new("#{CLASSIFICATION['text']}")
+        label = Qt::Label.new("#{classification_banner['display_text'].upcase}")
         label.setStyleSheet("margin:0px;")
 
         # Add stretchers on either side so it is always in the middle and looks nice

--- a/lib/cosmos/tools/tlm_viewer/screen.rb
+++ b/lib/cosmos/tools/tlm_viewer/screen.rb
@@ -234,12 +234,9 @@ module Cosmos
       @window = process(filename)
       @@open_screens << self if @window
 
-      #
-      # We want to add a classification bar to every Tool that gets launched. This is intentionally
-      #   hard coded here so a configuration file cannot make this not display
-      # There is a corresponding bar that gets added to every Tool (/lib/cosmos/gui/qt_tool.rb)
-      #
-
+      # Add a classification banner to every Tool that gets launched if the system configuration
+      #   called for one
+      # There is a corresponding banner that gets added to every Tool (/lib/cosmos/gui/qt_tool.rb)
       classification_banner = System.instance.classificiation_banner
       unless classification_banner.nil?
         # Get the RGB color information from the classification_banner

--- a/lib/cosmos/tools/tlm_viewer/screen.rb
+++ b/lib/cosmos/tools/tlm_viewer/screen.rb
@@ -233,6 +233,45 @@ module Cosmos
       @widgets = Widgets.new(self, mode)
       @window = process(filename)
       @@open_screens << self if @window
+
+      #
+      # We want to add a classification bar to every Tool that gets launched. This is intentionally
+      #   hard coded here so a configuration file cannot make this not display
+      # There is a corresponding bar that gets added to every Screen (/lib/cosmos/tools/tlm_viewer/screen.rb)
+      #
+
+      unless CLASSIFICATION.nil?
+        # Create a classification toolbar
+        classification_toolbar = Qt::ToolBar.new
+        # Disable right clicking on the bar (prevents it from being hidden unintentionally)
+        classification_toolbar.setContextMenuPolicy(Qt::PreventContextMenu)
+        # Freeze the bar at the top
+        classification_toolbar.setFloatable(false)
+        classification_toolbar.setMovable(false)
+        # Specify minimum sizes and set the style
+        classification_toolbar.minimumHeight = 20
+        classification_toolbar.maximumHeight = 20
+        classification_toolbar.setStyleSheet("background:#{CLASSIFICATION['color']};color:white;text-align:center;border:none;")
+
+        # Create a frame that will hold a horizontal layout
+        label_frame = Qt::Frame.new
+        label_layout = Qt::HBoxLayout.new(label_frame)
+        label_layout.setContentsMargins(0,1,0,0) # Centers the text nicely inside the horizontal layout
+
+        # Create a label of the classification and add it the horizontal layout
+        label = Qt::Label.new("#{CLASSIFICATION['text']}")
+        label.setStyleSheet("margin:0px;")
+
+        # Add stretchers on either side so it is always in the middle and looks nice
+        label_layout.addStretch(1)
+        label_layout.addWidget(label)
+        label_layout.addStretch(1)
+
+        # Add the frame to the main toolbar, then add the toolbar to the MainWindow
+        classification_toolbar.addWidget(label_frame)
+        self.addToolBar(classification_toolbar)
+      end
+
     end
 
     def widgets

--- a/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
+++ b/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
@@ -10,14 +10,14 @@
 
 require 'cosmos'
 Cosmos.catch_fatal_exception do
-  require 'cosmos/script'
-  require 'cosmos/tools/tlm_viewer/screen'
   require 'cosmos/gui/qt_tool'
   require 'cosmos/gui/dialogs/splash'
   require 'cosmos/gui/dialogs/progress_dialog'
   require 'cosmos/gui/dialogs/select_dialog'
   require 'cosmos/gui/widgets/full_text_search_line_edit'
   require 'cosmos/tools/tlm_viewer/tlm_viewer_config'
+  require 'cosmos/tools/tlm_viewer/screen'
+  require 'cosmos/script'
   require 'find'
   require 'fileutils'
 end


### PR DESCRIPTION
This commit is intended to add a classification bar to each tool and telemetry screen, useful for when you want to mark COSMOS for a certain classification level. Can be extended beyond classification to utilize any banner if one is desired.

Currently, the classification is defined/set in qt_tool.rb, however that can easily be changed to be more configuration driven. The initial request I had for this feature requested it be more hard-coded so it was locked down.

In order to avoid having to add a bar to each tool, I utilized the Qt::Toolbar, which can be placed relative to the Qt::MainWindow centralWidget (on top in this case), rather than adding it to each tool's centralWidget.

Let me know what you think!

