### PR TITLE
Allow protocol write methods to send commands

### DIFF
--- a/lib/cosmos/interfaces/interface.rb
+++ b/lib/cosmos/interfaces/interface.rb
@@ -283,7 +283,11 @@ module Cosmos
 
     # Wrap all writes in a mutex and handle errors
     def _write
-      @write_mutex.synchronize { yield }
+      if @write_mutex.owned?
+        yield
+      else
+        @write_mutex.synchronize { yield }
+      end
     rescue Exception => err
       Logger.instance.error("Error writing to interface : #{@name}")
       disconnect()


### PR DESCRIPTION
This is a potential solution to allow the protocol write family of methods to write to the interface they are attached to. See commit message.