### PR TITLE
Fix XTCE export and import

### DIFF
--- a/bin/xtce_converter
+++ b/bin/xtce_converter
@@ -68,7 +68,7 @@ end
 if input_filename
   packet_config = Cosmos::PacketConfig.new
   puts "Processing #{input_filename}..."
-  packet_config.process_xtce(input_filename)
+  packet_config.process_file(input_filename, nil)
   puts "Converting to COSMOS config files in #{output_dir}"
   packet_config.to_config(output_dir)
   puts "Success"

--- a/lib/cosmos/packets/packet_config.rb
+++ b/lib/cosmos/packets/packet_config.rb
@@ -85,7 +85,7 @@ module Cosmos
       @warnings = []
       @cmd_id_value_hash = {}
       @tlm_id_value_hash = {}
-      
+
       # Create unknown packets
       @commands['UNKNOWN'] = {}
       @commands['UNKNOWN']['UNKNOWN'] = Packet.new('UNKNOWN', 'UNKNOWN', :BIG_ENDIAN)
@@ -103,7 +103,8 @@ module Cosmos
     # knowledge of the commands, telemetry, and limits groups.
     #
     # @param filename [String] The name of the configuration file
-    # @param process_target_name [String] The target name
+    # @param process_target_name [String] The target name. Pass nil when parsing
+    #   an xtce file to automatically determine the target name.
     def process_file(filename, process_target_name)
       # Handle .xtce files
       if File.extname(filename).to_s.downcase == ".xtce"
@@ -286,13 +287,13 @@ module Cosmos
         if @current_cmd_or_tlm == COMMAND
           PacketParser.check_item_data_types(@current_packet)
           @commands[@current_packet.target_name][@current_packet.packet_name] = @current_packet
-          hash = @cmd_id_value_hash[@current_packet.target_name]        
+          hash = @cmd_id_value_hash[@current_packet.target_name]
           hash = {} unless hash
           @cmd_id_value_hash[@current_packet.target_name] = hash
           update_id_value_hash(hash)
         else
           @telemetry[@current_packet.target_name][@current_packet.packet_name] = @current_packet
-          hash = @tlm_id_value_hash[@current_packet.target_name]        
+          hash = @tlm_id_value_hash[@current_packet.target_name]
           hash = {} unless hash
           @tlm_id_value_hash[@current_packet.target_name] = hash
           update_id_value_hash(hash)

--- a/lib/cosmos/packets/parsers/xtce_converter.rb
+++ b/lib/cosmos/packets/parsers/xtce_converter.rb
@@ -295,6 +295,8 @@ module Cosmos
           xml['xtce'].IntegerDataEncoding(:sizeInBits => item.bit_size, :encoding => encoding)
           xml['xtce'].EnumerationList do
             item.states.each do |state_name, state_value|
+              # Skip the special COSMOS 'ANY' enumerated state
+              next if state_value == 'ANY'
               xml['xtce'].Enumeration(:value => state_value, :label => state_name)
             end
           end

--- a/lib/cosmos/packets/parsers/xtce_parser.rb
+++ b/lib/cosmos/packets/parsers/xtce_parser.rb
@@ -25,8 +25,8 @@ module Cosmos
     # @param warnings [Array<String>] Array of strings listing all the warnings
     #   that were created while parsing the configuration
     # @param filename [String] The name of the configuration file
-    # @param target_name [String] The target name
-    def self.process(commands, telemetry, warnings, filename, target_name)
+    # @param target_name [String] Override the target name found in the XTCE file
+    def self.process(commands, telemetry, warnings, filename, target_name = nil)
       XtceParser.new(commands, telemetry, warnings, filename, target_name)
     end
 
@@ -49,7 +49,7 @@ module Cosmos
 
     private
 
-    def initialize(commands, telemetry, warnings, filename, target_name)
+    def initialize(commands, telemetry, warnings, filename, target_name = nil)
       reset_processing_variables()
       @commands = commands
       @telemetry = telemetry
@@ -60,6 +60,7 @@ module Cosmos
 
     def parse(filename, target_name)
       doc = File.open(filename) { |f| Nokogiri::XML(f, nil, nil, Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NOBLANKS) }
+      # Determine the @current_target_name
       xtce_process_element(doc.root)
       @current_target_name = target_name if target_name
       doc.root.children.each do |child|


### PR DESCRIPTION
This has been broken since COSMOS 4.1.0 when I broke out the XTCE parser into its own class.
closes #992 
