### PR TITLE
Allow non-MD5 hashing algorithms, configurable in system.txt

### DIFF
--- a/data/config/system.yaml
+++ b/data/config/system.yaml
@@ -227,19 +227,21 @@ TIME_ZONE_UTC:
     affects packet receive times, timestamped log filenames, message logs,
     Cmd/Tlm extractor time ranges, etc.
   since: 3.10.0
-ADD_MD5_FILE:
-  summary: Add a file to the MD5 sum calculation
-  description: Adds a file to the set of files used in marshal file MD5 sum calculation.
-    Upon startup, COSMOS calculates an MD5 sum over the command/telemetry definition files
+ADD_HASH_FILE:
+  summary: Add a file to the hashing sum calculation
+  description: Adds a file to the set of files used in marshal file hashing sum calculation.
+    Upon startup, COSMOS calculates a hashing sum over the command/telemetry definition files
     for all targets. After the definitions have been processed, COSMOS saves the resulting
-    objects as marshal files in a folder with the MD5 sum as part of the name.
-    The next time COSMOS runs, if the MD5 checksum of the cmd/tlm definition files
+    objects as marshal files in a folder with the hashing sum as part of the name.
+    The next time COSMOS runs, if the hashing sum of the cmd/tlm definition files
     has not changed, COSMOS can load the marshal files instead of re-processing the definitions.
-    If a file is specified with the ADD_MD5_FILE keyword, COSMOS will include it in the
-    MD5 sum calculation. This means that a change in the file will cause COSMOS to
+    If a file is specified with the ADD_HASH_FILE keyword, COSMOS will include it in the
+    hashing sum calculation. This means that a change in the file will cause COSMOS to
     re-process the cmd/tlm defintions and create a new set of marshal files.
-  since: 4.0.0
-  example: ADD_MD5_FILE lib/user_version.rb
+    The default hashing algorithm is MD5, but other Ruby Digest algorithms are also supported,
+    like SHA1 and SHA256
+  since: 4.3.1
+  example: ADD_HASH_FILE lib/user_version.rb
   parameters:
     - name: Filename
       required: true
@@ -268,3 +270,15 @@ CLASSIFICATION:
       required: false
       description: The blue value of a RGB triplet
       values: '\d+'
+HASHING_ALGORITHM:
+  summary: Specify which Ruby Digest hashing algorithm to use
+  description: Set the hashing algorithm used for config hashing, tlm_viewer hashing, and
+    script hashing. COSMOS will truncate the resulting hash string down to 32 characters
+  since: 4.3.1
+  example: HASHING_ALGORITHM SHA256
+  parameters:
+    - name: Algorithm
+      required: true
+      description: Digest algorithm, one of MD5, RMD160, SHA1, SHA256, SHA384, SHA512
+      values: .+
+

--- a/data/config/system.yaml
+++ b/data/config/system.yaml
@@ -240,7 +240,7 @@ ADD_HASH_FILE:
     re-process the cmd/tlm defintions and create a new set of marshal files.
     The default hashing algorithm is MD5, but other Ruby Digest algorithms are also supported,
     like SHA1 and SHA256
-  since: 4.3.1
+  since: 4.4.0
   example: ADD_HASH_FILE lib/user_version.rb
   parameters:
     - name: Filename
@@ -274,7 +274,7 @@ HASHING_ALGORITHM:
   summary: Specify which Ruby Digest hashing algorithm to use
   description: Set the hashing algorithm used for config hashing, tlm_viewer hashing, and
     script hashing. COSMOS will truncate the resulting hash string down to 32 characters
-  since: 4.3.1
+  since: 4.4.0
   example: HASHING_ALGORITHM SHA256
   parameters:
     - name: Algorithm

--- a/demo/config/system/system.txt
+++ b/demo/config/system/system.txt
@@ -66,7 +66,7 @@ ENABLE_SOUND
 # Initialize the metadata dialog using values from the following file:
 META_INIT config/data/meta_init.txt
 
-ADD_MD5_FILE lib/user_version.rb
+ADD_HASH_FILE lib/user_version.rb
 
 # Banner examples
 # Create a banner using an existing COSMOS color (Cosmos::GREEN in this case)

--- a/demo/config/system/system_alt_ports.txt
+++ b/demo/config/system/system_alt_ports.txt
@@ -66,4 +66,4 @@ ENABLE_SOUND
 # Initialize the metadata dialog using values from the following file:
 META_INIT config/data/meta_init.txt
 
-ADD_MD5_FILE lib/user_version.rb
+ADD_HASH_FILE lib/user_version.rb

--- a/install/config/system/system.txt
+++ b/install/config/system/system.txt
@@ -61,4 +61,4 @@ ALLOW_ACCESS ALL
 # Initialize the metadata dialog using values from the following file:
 # META_INIT config/data/meta_init.txt
 
-# ADD_MD5_FILE lib/user_version.rb
+# ADD_HASH_FILE lib/user_version.rb

--- a/lib/cosmos/dart/lib/dart_common.rb
+++ b/lib/cosmos/dart/lib/dart_common.rb
@@ -202,7 +202,7 @@ module DartCommon
   # can't be loaded locally, it is requested from the server and copied
   # locally before proceeding.
   #
-  # @param system_config_name [String] System configuration name (MD5) to load
+  # @param system_config_name [String] System configuration name (hashing sum) to load
   def switch_and_get_system_config(system_config_name)
     # Switch to this new system configuration
     current_config, error = Cosmos::System.load_configuration(system_config_name)

--- a/lib/cosmos/packets/packet.rb
+++ b/lib/cosmos/packets/packet.rb
@@ -8,7 +8,7 @@
 # as published by the Free Software Foundation; version 3 with
 # attribution addendums as found in the LICENSE.txt
 
-require 'digest/md5'
+require 'digest'
 require 'cosmos/packets/structure'
 require 'cosmos/packets/packet_item'
 require 'cosmos/ext/packet' if RUBY_ENGINE == 'ruby' and !ENV['COSMOS_NO_EXT']
@@ -249,7 +249,7 @@ module Cosmos
       end
     end
 
-    # Calculates a unique MD5Sum that changes if the parts of the packet configuration change that could affect
+    # Calculates a unique hashing sum that changes if the parts of the packet configuration change that could affect
     # the "shape" of the packet.  This value is cached and that packet should not be changed if this method is being used
     def config_name
       return @config_name if @config_name
@@ -257,7 +257,9 @@ module Cosmos
       @sorted_items.each do |item|
         string << " ITEM #{item.name} #{item.bit_offset} #{item.bit_size} #{item.data_type} #{item.array_size} #{item.endianness} #{item.overflow} #{item.states} #{item.read_conversion ? item.read_conversion.class : 'NO_CONVERSION'}"
       end
-      digest = Digest::MD5.new
+
+      # Use the hashing algorithm established by Cosmos::System
+      digest = Digest.const_get(System.hashing_algorithm).send('new')
       digest << string
       @config_name = digest.hexdigest
       @config_name

--- a/lib/cosmos/system/target.rb
+++ b/lib/cosmos/system/target.rb
@@ -231,7 +231,7 @@ module Cosmos
       cmd_tlm_files.sort!
     end
 
-    # Make sure all partials are included in the cmd_tlm list for the MD5 calculation
+    # Make sure all partials are included in the cmd_tlm list for the hashing sum calculation
     def add_cmd_tlm_partials(dir)
       partial_files = []
       if Dir.exist?(File.join(dir, 'cmd_tlm'))

--- a/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
+++ b/lib/cosmos/tools/tlm_viewer/tlm_viewer.rb
@@ -59,7 +59,7 @@ module Cosmos
     def self.load_config(filename)
       raise "Configuration file #{filename} does not exist." unless filename && File.exist?(filename)
 
-      # Find all screen files so we can calculate MD5
+      # Find all screen files so we can calculate hashing sum
       tlmviewer_files = [filename, System.initial_filename]
       additional_data = ''
       System.targets.each do |target_name, target|
@@ -79,9 +79,13 @@ module Cosmos
           end
         end
       end
-      # Calculate MD5 and attempt to load marshal file
-      md5 = Cosmos.md5_files(tlmviewer_files, additional_data)
-      marshal_filename = File.join(System.paths['TMP'], "tlmviewer_#{md5.hexdigest}.bin")
+      # Calculate the hashing sum and attempt to load marshal file
+      hashing_result = Cosmos.hash_files(tlmviewer_files, additional_data, System.hashing_algorithm)
+      # Only use at most, 32 characters of the hex
+      hash_string = hashing_result.hexdigest
+      hash_string = hash_string[-32..-1] if hash_string.length >= 32
+
+      marshal_filename = File.join(System.paths['TMP'], "tlmviewer_#{hash_string}.bin")
       config = Cosmos.marshal_load(marshal_filename)
       unless config
         # Marshal file load failed - Manually load configuration

--- a/lib/cosmos/top_level.rb
+++ b/lib/cosmos/top_level.rb
@@ -11,7 +11,7 @@
 # This file contains top level functions in the Cosmos namespace
 
 require 'thread'
-require 'digest/md5'
+require 'digest'
 require 'open3'
 require 'cosmos/core_ext'
 require 'cosmos/version'
@@ -382,24 +382,26 @@ module Cosmos
     end
   end
 
-  # Runs an md5 sum over one or more files and returns the Digest::MD5 object.
+  # Runs a hash algorithm over one or more files and returns the Digest object.
   # Handles windows/unix new line differences but changes in whitespace will
-  # change the md5 sum.
+  # change the hash sum.
   #
   # Usage:
-  #   digest = Cosmos.md5_files(files)
+  #   digest = Cosmos.hash_files(files, additional_data, hashing_algorithm)
   #   digest.digest # => the 16 bytes of digest
   #   digest.hexdigest # => the formatted string in hex
   #
-  # @param filenames [Array<String>] List of files to read and calculate a md5
+  # @param filenames [Array<String>] List of files to read and calculate a hashing
   #   sum on
-  # @param additional_data [String] Additional data to add to the md5 sum
-  # @return [Digest::MD5] The md5 sum
-  def self.md5_files(filenames, additional_data = nil)
-    digest = Digest::MD5.new
+  # @param additional_data [String] Additional data to add to the hashing sum
+  # @param hashing_algorithm [String] Hashing algorithm to use
+  # @return [Digest::<algorithm>] The hashing sum object
+  def self.hash_files(filenames, additional_data = nil, hashing_algorithm = 'MD5')
+    digest = Digest.const_get(hashing_algorithm).send('new')
+
     Cosmos.set_working_dir do
       filenames.each do |filename|
-        # Read the file's data and add to the running MD5 sum
+        # Read the file's data and add to the running hashing sum
         digest << File.read(filename).gsub(/\r/,'')
       end
     end

--- a/spec/top_level/top_level_spec.rb
+++ b/spec/top_level/top_level_spec.rb
@@ -235,17 +235,28 @@ module Cosmos
     end
   end
 
-  describe "md5_files" do
-    it "calculates a MD5 sum across files" do
+  describe "hash_files" do
+    it "calculates a hashing sum across files in md5 mode" do
       File.open(File.join(Cosmos::USERPATH,'test1.txt'),'w') {|f| f.puts "test1" }
       File.open(File.join(Cosmos::USERPATH,'test2.txt'),'w') {|f| f.puts "test2" }
-      digest = Cosmos.md5_files(["test1.txt", "test2.txt"])
+      digest = Cosmos.hash_files(["test1.txt", "test2.txt"])
       expect(digest.digest.length).to be 16
       expect(digest.hexdigest).to eql 'e51dfbea83de9c7e6b49560089d8a170'
       File.delete(File.join(Cosmos::USERPATH, 'test1.txt'))
       File.delete(File.join(Cosmos::USERPATH, 'test2.txt'))
     end
+
+    it "calculates a hashing sum across files in sha256 mode" do
+      File.open(File.join(Cosmos::USERPATH,'test1.txt'),'w') {|f| f.puts "test1" }
+      File.open(File.join(Cosmos::USERPATH,'test2.txt'),'w') {|f| f.puts "test2" }
+      digest = Cosmos.hash_files(["test1.txt", "test2.txt"], nil, 'SHA256')
+      expect(digest.digest.length).to be 32
+      expect(digest.hexdigest).to eql '49789e7c809eb38ea34864b00e2cfd68825e0c07cd7b7d0c6fe2642ac87a919c'
+      File.delete(File.join(Cosmos::USERPATH, 'test1.txt'))
+      File.delete(File.join(Cosmos::USERPATH, 'test2.txt'))
+    end
   end
+
 
   describe "create_log_file" do
     it "creates a log file in System LOGS" do


### PR DESCRIPTION
This pull request is designed to allow users to specify which Hashing Algorithm within Digest they would like to use.

Specifically, it solves the issue of certain security setups that don't allow for 'weaker' hash algorithms.