### PR TITLE
Scripting doc example fix

### DIFF
--- a/_docs/scripting.md
+++ b/_docs/scripting.md
@@ -1171,7 +1171,7 @@ get_tlm_details(<items>)
 
 Example:
 ```ruby
-details = get_tlm_details("INST", "HEALTH_STATUS", "COLLECTS")
+details = get_tlm_details([["INST", "HEALTH_STATUS", "COLLECTS"]])
 ```
 
 ### get_tlm_cnt (since 3.9.2)


### PR DESCRIPTION
Provided example for get_tlm_details doesn't work, need to give it an array of arrays