### PR TITLE
#1016 Make rpc function names case-insensitive

### DIFF
--- a/lib/cosmos/io/json_drb.rb
+++ b/lib/cosmos/io/json_drb.rb
@@ -259,10 +259,10 @@ module Cosmos
         error_code = nil
         response_data = nil
 
-        if (@method_whitelist and @method_whitelist.include?(request.method)) or
-           (!@method_whitelist and !JsonRpcRequest::DANGEROUS_METHODS.include?(request.method))
+        if (@method_whitelist and @method_whitelist.include?(request.method.downcase())) or
+           (!@method_whitelist and !JsonRpcRequest::DANGEROUS_METHODS.include?(request.method.downcase()))
           begin
-            result = @object.send(request.method.intern, *request.params)
+            result = @object.send(request.method.downcase().intern, *request.params)
             if request.id
               response = JsonRpcSuccessResponse.new(result, request.id)
             end

--- a/spec/io/json_drb_spec.rb
+++ b/spec/io/json_drb_spec.rb
@@ -200,6 +200,20 @@ module Cosmos
         sleep(0.1)
       end
 
+      it "processes success requests with uppercase" do
+        class MyServer5
+          def my_method(param)
+          end
+        end
+
+        @json.start_service('127.0.0.1', 7777, MyServer5.new)
+        request_data = JsonRpcRequest.new('MY_METHOD', 'param', 1).to_json
+        _, error_code = @json.process_request(request_data, Time.now)
+        expect(error_code).to eq nil
+        @json.stop_service
+        sleep(0.1)
+      end
+
       it "does not allow dangerous methods" do
         @json.start_service('127.0.0.1', 7777, self)
         request_data = JsonRpcRequest.new('send', 'param', 1).to_json


### PR DESCRIPTION
These changes address #1016 to make RPC calls case-insensitive. I can understand only wanting lowercase API calls by design, but these changes are here if that's not the case. 

I have added a unit test and tested these changes manually by sending POST requests to the RPC API. Also, I think this the only location in the code where RPC method names are checked, but I'm not very familiar with the code so I might have missed something. If this change is going to be accepted, it had better be uniform across all RPC methods. 

This change is useful because I spent some time once debugging failing RPC calls and it took awhile to realize I was sending "Cmd" instead of "cmd". This change makes the API accept those requests as well. See https://en.wikipedia.org/wiki/Robustness_principle...

Also, I wasn't sure how to "deploy" local changes to the local demo install of COSMOS. For anyone's future reference, this is what I did to get that working:
bundle exec rake gem VERSION=5.5.5
cd demo
gem install ../cosmos-5.5.5.gem
bundle install
bundle update cosmos 