### PR TITLE
Fix logger level comments

### DIFF
--- a/lib/cosmos/utilities/logger.rb
+++ b/lib/cosmos/utilities/logger.rb
@@ -25,17 +25,17 @@ module Cosmos
 
     @@instance = nil
 
-    # DEBUG only prints DEBUG messages
+    # DEBUG always prints
     DEBUG = ::Logger::DEBUG
-    # INFO prints INFO, DEBUG messages
+    # INFO prints INFO, WARN, ERROR, FATAL, UNKNOWN messages
     INFO  = ::Logger::INFO
-    # WARN prints WARN, INFO, DEBUG messages
+    # WARN prints WARN, ERROR, FATAL, UNKNOWN messages
     WARN  = ::Logger::WARN
-    # ERROR prints ERROR, WARN, INFO, DEBUG messages
+    # ERROR prints ERROR, FATAL, UNKNOWN messages
     ERROR = ::Logger::ERROR
-    # FATAL prints FATAL, ERROR, WARN, INFO, DEBUG messages
+    # FATAL prints FATAL, UNKNOWN messages
     FATAL = ::Logger::FATAL
-    # UNKNOWN always prints
+    # UNKNOWN only prints UNKNOWN messages
     UNKNOWN = ::Logger::UNKNOWN
 
     DEBUG_SEVERITY_STRING = ' DEBUG:'


### PR DESCRIPTION
Comments indicated that DEBUG would only print DEBUG level log messages and UNKNOWN would print all log messages. DEBUG prints all log messages and UNKNOWN only prints UNKNOWN level log messages.

``` ruby
debug_logger = Cosmos::Logger.new(Cosmos::Logger::DEBUG)
debug_logger.debug("debug_logger.debug")     #=> 2020/11/09 23:31:08.540  DEBUG: debug_logger.debug
debug_logger.warn("debug_logger.warn")       #=> 2020/11/09 23:31:08.541  WARN: debug_logger.warn
debug_logger.unknown("debug_logger.unknown") #=> 2020/11/09 23:31:08.542  debug_logger.unknown

warn_logger = Cosmos::Logger.new(Cosmos::Logger::WARN)
warn_logger.debug("warn_logger.debug")     #=>
warn_logger.warn("warn_logger.warn")       #=> 2020/11/09 23:31:08.541  WARN: warn_logger.warn
warn_logger.unknown("warn_logger.unknown") #=> 2020/11/09 23:31:08.542  warn_logger.unknown

unknown_logger = Cosmos::Logger.new(Cosmos::Logger::UNKNOWN)
unknown_logger.debug("unknown_logger.debug")     #=>
unknown_logger.warn("unknown_logger.warn")       #=>
unknown_logger.unknown("unknown_logger.unknown") #=> 2020/11/09 23:33:56.517  unknown_logger.unknown
