### PR TITLE
Fix Dockerfile

### DIFF
--- a/cosmos-redis/Dockerfile
+++ b/cosmos-redis/Dockerfile
@@ -1,6 +1,6 @@
 FROM redis:6.2
 
 RUN mkdir /config
-COPY ./config/* /config
+COPY ./config/* /config/
 
 CMD [ "redis-server", "/config/redis.conf" ]


### PR DESCRIPTION
Hi,

Fixing a docker build error:

```
Step 3/4 : COPY ./config/* /config
When using COPY with more than one source file, the destination must be a directory and end with a /
```
