### PR TITLE
cosmos-cmd-tlm-api: plugins_controller#install: more descriptive 500 error

### DIFF
--- a/cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
+++ b/cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
@@ -70,8 +70,8 @@ class PluginsController < ModelController
     end
     begin
       render :json => Cosmos::PluginModel.install_phase2(params[:id], JSON.parse(params[:variables]), scope: params[:scope])
-    rescue
-      head :internal_server_error
+    rescue Exception => e
+      render(:json => { 'status' => 'error', 'message' => e.message }, :status => 500) and return
     end
   end
 end


### PR DESCRIPTION
Following the advice that we received in #1334, we could troubleshoot one of the issues by debugging the server logs in the `ballaerospace/cosmosc2-cmd-tlm-api` container.

With this changeset, we could understand that we have to have the first argument to the `TARGET` parameter to always match the file name of the plugin. Otherwise, we get the 500 error when we upload the plugin's gem file via the admin interface.

```
VARIABLE ip localhost
VARIABLE port_tm 1235
VARIABLE port_tc 1234
VARIABLE sample_target_name SAMPLE
 
TARGET SAMPLE <%= sample_target_name %>
# hostname   write_dest_port   read_port   write_src_port   interface_address   ttl   write_timeout   read_timeout   bind_address
INTERFACE <%= sample_target_name %>_INT udp_interface.rb <%= ip %> <%= port_tc %> <%= port_tm %> nil nil 128 nil nil
  MAP_TARGET <%= sample_target_name %>
```

This was the error that helped us to understand the problem with the target name:

```json
{
    "status":"error",
    "message":"No target files found at /tmp/d20210817-8-1h8z2dm/gem/targets/TEST/**/*\n\nParsed output in /tmp/cosmos/tmp/tmp/d20210817-8-1h8z2dm/gem/plugin.txt"
}