### PR TITLE
Improve error reporting

### DIFF
--- a/cosmos/lib/cosmos/system/system.rb
+++ b/cosmos/lib/cosmos/system/system.rb
@@ -118,7 +118,7 @@ module Cosmos
       target.cmd_tlm_files.each do |cmd_tlm_file|
         @packet_config.process_file(cmd_tlm_file, target.name)
       rescue Exception => err
-        Logger.error "Problem processing #{cmd_tlm_file}."
+        Logger.error "Problem processing #{cmd_tlm_file}: #{err}."
         raise err
       end
     end


### PR DESCRIPTION
I tried to write a bad `tlm.txt` file, writing the size in bytes instead of bits. I found the debugging process harder than expected. Here is a small PR to add the error message in the logs. It would also be nice to show it in the plugin upload view, instead of a plain "Error: Request failed with status code 500".

Before:

```
{"time":1634041796889431343,"@timestamp":"2021-10-12T12:29:56.889+00:00","severity":"ERROR","container_name":"11316e76da44","log":"Problem processing /tmp/d20211012-7-z0hsgz/SAMPLE/cmd_tlm/cfs_tlm.txt."}
```

After:

```
{"time":1634042409388898449,"@timestamp":"2021-10-12T12:40:09.388+00:00","severity":"ERROR","container_name":"e97ee7ec5f57","log":"Problem processing /tmp/d20211012-7-1o51tb1/SAMPLE/cmd_tlm/cfs_tlm.txt: LASTVALTABLENAME: bit_size for STRING and BLOCK items must be byte multiples\n\nParsed output in /tmp/cosmos/tmp/tmp/d20211012-7-1o51tb1/SAMPLE/cmd_tlm/cfs_tlm.txt."}
```

---

For anyone trying the debug Cosmos, here is how I was doing it:

```
# Sprinkle some
Logger.instance.error "==>> #{__FILE__}:#{__LINE__}: #{__method__.to_s()}"

# Recompile, restart and show logs
bash cosmos-control.sh start && docker logs cosmos_cosmos-cmd-tlm-api_1 --follow
```

CC #1353
