### PR TITLE
Append dot to end of "blah" hostnames in specs

### DIFF
--- a/spec/io/json_drb_object_spec.rb
+++ b/spec/io/json_drb_object_spec.rb
@@ -16,7 +16,7 @@ module Cosmos
   describe JsonDRbObject do
     describe "initialize" do
       it "rescues bad hosts" do
-        expect { JsonDRbObject.new("blah", 7777) }.to raise_error("Invalid hostname: blah")
+        expect { JsonDRbObject.new("blah.", 7777) }.to raise_error("Invalid hostname: blah.")
       end
     end
 

--- a/spec/system/system_spec.rb
+++ b/spec/system/system_spec.rb
@@ -833,7 +833,7 @@ module Cosmos
 
         it "complains about bad addresses" do
           tf = Tempfile.new('unittest')
-          tf.puts("ALLOW_ACCESS blah")
+          tf.puts("ALLOW_ACCESS blah.")
           tf.close
           expect { System.instance.process_file(tf.path) }.to raise_error(ConfigParser::Error)
           tf.unlink


### PR DESCRIPTION
Prevents specs from failing on networks where "blah" resolves to a valid 
hostname.