### PR TITLE
Remove old interface code for inject_tlm

### DIFF
--- a/cosmos/bin/cosmos
+++ b/cosmos/bin/cosmos
@@ -280,9 +280,13 @@ def load_plugin(plugin_file_path, scope:, variables_file: nil)
     end
     unless found
       puts "Loading new plugin: #{plugin_file_path}"
-      variables = nil
-      variables = JSON.parse(File.read(variables_file)) if variables_file
-      plugin_hash = Cosmos::PluginModel.install_phase1(plugin_file_path, variables, scope: scope)
+      if variables_file
+        # Assume phase1 is already done
+        variables = JSON.parse(File.read(variables_file))
+        plugin_hash = Cosmos::PluginModel.new(name: File.basename(plugin_file_path), variables: variables, scope: scope).as_json
+      else
+        plugin_hash = Cosmos::PluginModel.install_phase1(plugin_file_path, scope: scope)
+      end
       Cosmos::PluginModel.install_phase2(plugin_hash['name'], plugin_hash['variables'], scope: scope)
     end
   rescue => err

--- a/cosmos/lib/cosmos/api/tlm_api.rb
+++ b/cosmos/lib/cosmos/api/tlm_api.rb
@@ -111,11 +111,11 @@ module Cosmos
 
     # Injects a packet into the system as if it was received from an interface
     #
-    # @param target_name[String] Target name of the packet
-    # @param packet_name[String] Packet name of the packet
-    # @param item_hash[Hash] Hash of item_name and value for each item you want to change from the current value table
+    # @param target_name [String] Target name of the packet
+    # @param packet_name [String] Packet name of the packet
+    # @param item_hash [Hash] Hash of item_name and value for each item you want to change from the current value table
     # @param type [Symbol] Telemetry type, :RAW, :CONVERTED (default), :FORMATTED, or :WITH_UNITS
-    def inject_tlm(target_name, packet_name, item_hash = nil, log: true, type: :CONVERTED, scope: $cosmos_scope, token: $cosmos_token)
+    def inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, scope: $cosmos_scope, token: $cosmos_token)
       authorize(permission: 'tlm_set', target_name: target_name, packet_name: packet_name, scope: scope, token: token)
       unless CvtModel::VALUE_TYPES.include?(type.intern)
         raise "Unknown type '#{type}' for #{target_name} #{packet_name}"

--- a/cosmos/lib/cosmos/microservices/interface_microservice.rb
+++ b/cosmos/lib/cosmos/microservices/interface_microservice.rb
@@ -83,11 +83,6 @@ module Cosmos
             @interface.write_raw(msg_hash['raw'])
             next 'SUCCESS'
           end
-          if msg_hash['inject_tlm']
-            Logger.info "#{@interface.name}: Inject telemetry" if msg_hash['log']
-            @tlm.inject_tlm(msg_hash)
-            next 'SUCCESS'
-          end
           if msg_hash.key?('log_raw')
             if msg_hash['log_raw'] == 'true'
               Logger.info "#{@interface.name}: Enable raw logging"
@@ -410,16 +405,6 @@ module Cosmos
       # Write to stream
       packet.received_count += 1
       TelemetryTopic.write_packet(packet, scope: @scope)
-    end
-
-    def inject_tlm(hash)
-      packet = System.telemetry.packet(hash['target_name'], hash['packet_name']).clone
-      if hash['item_hash']
-        JSON.parse(hash['item_hash']).each do |item, value|
-          packet.write(item.to_s, value, hash['type'].to_sym)
-        end
-      end
-      handle_packet(packet)
     end
 
     def handle_connection_failed(connect_error)


### PR DESCRIPTION
closes #1511 

Turns out a previous refactor already removed the logging for inject_tlm. Not sure what additional 'cmd' logging the ticket is referring to.