### PR TITLE
Logging Optimizations

### DIFF
--- a/cosmos/ext/cosmos/ext/cosmos_io/cosmos_io.c
+++ b/cosmos/ext/cosmos/ext/cosmos_io/cosmos_io.c
@@ -30,19 +30,19 @@ VALUE mCosmosIO = Qnil;
 static ID id_method_read = 0;
 
 /* Reads a length field and then return the String resulting from reading the
-  * number of bytes the length field indicates
-  *
-  * For example:
-  *   io = StringIO.new
-  *   # where io is "\x02\x01\x02\x03\x04...."
-  *   result = io.read_length_bytes(1)
-  *   # result will be "\x01x02" because the length field was given
-  *   # to be 1 byte. We read 1 byte which is a 2. So we then read two
-  *   # bytes and return.
-  *
-  * @param length_num_bytes [Integer] Number of bytes in the length field
-  * @return [String] A String of "length field" number of bytes
-  */
+ * number of bytes the length field indicates
+ *
+ * For example:
+ *   io = StringIO.new
+ *   # where io is "\x02\x01\x02\x03\x04...."
+ *   result = io.read_length_bytes(1)
+ *   # result will be "\x01x02" because the length field was given
+ *   # to be 1 byte. We read 1 byte which is a 2. So we then read two
+ *   # bytes and return.
+ *
+ * @param length_num_bytes [Integer] Number of bytes in the length field
+ * @return [String] A String of "length field" number of bytes
+ */
 static VALUE read_length_bytes(int argc, VALUE *argv, VALUE self)
 {
   int length_num_bytes = 0;
@@ -134,7 +134,7 @@ static VALUE read_length_bytes(int argc, VALUE *argv, VALUE self)
   }
 
   /* Read String */
-  temp_string_length = UINT2NUM(string_length);
+  temp_string_length = UINT2NUM((unsigned int)string_length);
   return_value = rb_funcall(self, id_method_read, 1, temp_string_length);
   if (NIL_P(return_value) || (RSTRING_LEN(return_value) != string_length))
   {

--- a/cosmos/ext/cosmos/ext/packet/packet.c
+++ b/cosmos/ext/cosmos/ext/packet/packet.c
@@ -196,7 +196,7 @@ static VALUE packet_initialize(int argc, VALUE *argv, VALUE self)
     packet_name = argv[1];
     default_endianness = symbol_BIG_ENDIAN;
     description = Qnil;
-    buffer = rb_str_new2("");
+    buffer = Qnil;
     item_class = cPacketItem;
     break;
   case 3:
@@ -204,7 +204,7 @@ static VALUE packet_initialize(int argc, VALUE *argv, VALUE self)
     packet_name = argv[1];
     default_endianness = argv[2];
     description = Qnil;
-    buffer = rb_str_new2("");
+    buffer = Qnil;
     item_class = cPacketItem;
     break;
   case 4:
@@ -212,7 +212,7 @@ static VALUE packet_initialize(int argc, VALUE *argv, VALUE self)
     packet_name = argv[1];
     default_endianness = argv[2];
     description = argv[3];
-    buffer = rb_str_new2("");
+    buffer = Qnil;
     item_class = cPacketItem;
     break;
   case 5:

--- a/cosmos/ext/cosmos/ext/structure/structure.c
+++ b/cosmos/ext/cosmos/ext/structure/structure.c
@@ -56,6 +56,7 @@ static ID id_method_reverse = 0;
 static ID id_method_Integer = 0;
 static ID id_method_Float = 0;
 static ID id_method_kind_of = 0;
+static ID id_method_allocate_buffer = 0;
 
 static ID id_ivar_buffer = 0;
 static ID id_ivar_bit_offset = 0;
@@ -520,7 +521,8 @@ static VALUE binary_accessor_read(VALUE self, VALUE param_bit_offset, VALUE para
     {
       string_length = upper_bound - lower_bound + 1;
       string = malloc(string_length + 1);
-      if (string == NULL) {
+      if (string == NULL)
+      {
         rb_raise(rb_eNoMemError, "malloc of %d returned NULL", string_length + 1);
       }
       memcpy(string, buffer + lower_bound, string_length);
@@ -577,7 +579,8 @@ static VALUE binary_accessor_read(VALUE self, VALUE param_bit_offset, VALUE para
       string_length = ((bit_size - 1) / 8) + 1;
       array_length = string_length + 4; /* Required number of bytes plus slack */
       unsigned_char_array = (unsigned char *)malloc(array_length);
-      if (unsigned_char_array == NULL) {
+      if (unsigned_char_array == NULL)
+      {
         rb_raise(rb_eNoMemError, "malloc of %d returned NULL", array_length);
       }
       read_bitfield(lower_bound, upper_bound, bit_offset, bit_size, given_bit_offset, given_bit_size, param_endianness, buffer, (int)buffer_length, unsigned_char_array);
@@ -692,7 +695,8 @@ static VALUE binary_accessor_read(VALUE self, VALUE param_bit_offset, VALUE para
       string_length = ((bit_size - 1) / 8) + 1;
       array_length = string_length + 4; /* Required number of bytes plus slack */
       unsigned_char_array = (unsigned char *)malloc(array_length);
-      if (unsigned_char_array == NULL) {
+      if (unsigned_char_array == NULL)
+      {
         rb_raise(rb_eNoMemError, "malloc of %d returned NULL", array_length);
       }
       read_bitfield(lower_bound, upper_bound, bit_offset, bit_size, given_bit_offset, given_bit_size, param_endianness, buffer, (int)buffer_length, unsigned_char_array);
@@ -1147,7 +1151,8 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
       string_length = ((bit_size - 1) / 8) + 1;
       array_length = string_length + 4; /* Required number of bytes plus slack */
       unsigned_char_array = (unsigned char *)malloc(array_length);
-      if (unsigned_char_array == NULL) {
+      if (unsigned_char_array == NULL)
+      {
         rb_raise(rb_eNoMemError, "malloc of %d returned NULL", array_length);
       }
 
@@ -1275,15 +1280,8 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
  */
 static int get_int_length(VALUE self)
 {
-  volatile VALUE buffer = rb_ivar_get(self, id_ivar_buffer);
-  if (RTEST(buffer))
-  {
-    return (int)RSTRING_LEN(buffer);
-  }
-  else
-  {
-    return 0;
-  }
+  rb_funcall(self, id_method_allocate_buffer, 0);
+  return (int)RSTRING_LEN(rb_ivar_get(self, id_ivar_buffer));
 }
 
 /*
@@ -1310,24 +1308,21 @@ static VALUE read_item_internal(VALUE self, VALUE item, VALUE buffer)
     return Qnil;
   }
 
-  if (RTEST(buffer))
+  if (!(RTEST(buffer)))
   {
-    bit_offset = rb_ivar_get(item, id_ivar_bit_offset);
-    bit_size = rb_ivar_get(item, id_ivar_bit_size);
-    array_size = rb_ivar_get(item, id_ivar_array_size);
-    endianness = rb_ivar_get(item, id_ivar_endianness);
-    if (RTEST(array_size))
-    {
-      return rb_funcall(cBinaryAccessor, id_method_read_array, 6, bit_offset, bit_size, data_type, array_size, buffer, endianness);
-    }
-    else
-    {
-      return binary_accessor_read(cBinaryAccessor, bit_offset, bit_size, data_type, buffer, endianness);
-    }
+    buffer = rb_funcall(self, id_method_allocate_buffer, 0);
+  }
+  bit_offset = rb_ivar_get(item, id_ivar_bit_offset);
+  bit_size = rb_ivar_get(item, id_ivar_bit_size);
+  array_size = rb_ivar_get(item, id_ivar_array_size);
+  endianness = rb_ivar_get(item, id_ivar_endianness);
+  if (RTEST(array_size))
+  {
+    return rb_funcall(cBinaryAccessor, id_method_read_array, 6, bit_offset, bit_size, data_type, array_size, buffer, endianness);
   }
   else
   {
-    rb_raise(rb_eRuntimeError, "No buffer given to read_item");
+    return binary_accessor_read(cBinaryAccessor, bit_offset, bit_size, data_type, buffer, endianness);
   }
 }
 
@@ -1404,8 +1399,8 @@ static VALUE structure_item_spaceship(VALUE self, VALUE other_item)
   if ((bit_offset == 0) && (other_bit_offset == 0))
   {
     /* Both bit_offsets are 0 so sort by bit_size
-      * This allows derived items with bit_size of 0 to be listed first
-      * Compare based on bit size */
+     * This allows derived items with bit_size of 0 to be listed first
+     * Compare based on bit size */
     bit_size = FIX2INT(rb_ivar_get(self, id_ivar_bit_size));
     other_bit_size = FIX2INT(rb_ivar_get(other_item, id_ivar_bit_size));
     if (bit_size == other_bit_size)
@@ -1518,12 +1513,12 @@ static VALUE structure_initialize(int argc, VALUE *argv, VALUE self)
   {
   case 0:
     default_endianness = HOST_ENDIANNESS;
-    buffer = rb_str_new2("");
+    buffer = Qnil;
     item_class = cStructureItem;
     break;
   case 1:
     default_endianness = argv[0];
-    buffer = rb_str_new2("");
+    buffer = Qnil;
     item_class = cStructureItem;
     break;
   case 2:
@@ -1592,6 +1587,10 @@ static VALUE resize_buffer(VALUE self)
       rb_str_concat(buffer, rb_str_times(ZERO_STRING, INT2FIX(defined_length - current_length)));
     }
   }
+  else
+  {
+    rb_funcall(self, id_method_allocate_buffer, 0);
+  }
 
   return self;
 }
@@ -1618,6 +1617,7 @@ void Init_structure(void)
   id_method_Integer = rb_intern("Integer");
   id_method_Float = rb_intern("Float");
   id_method_kind_of = rb_intern("kind_of?");
+  id_method_allocate_buffer = rb_intern("allocate_buffer");
 
   MIN_INT8 = INT2NUM(-128);
   MAX_INT8 = INT2NUM(127);

--- a/cosmos/ext/cosmos/ext/structure/structure.c
+++ b/cosmos/ext/cosmos/ext/structure/structure.c
@@ -56,7 +56,7 @@ static ID id_method_reverse = 0;
 static ID id_method_Integer = 0;
 static ID id_method_Float = 0;
 static ID id_method_kind_of = 0;
-static ID id_method_allocate_buffer = 0;
+static ID id_method_allocate_buffer_if_needed = 0;
 
 static ID id_ivar_buffer = 0;
 static ID id_ivar_bit_offset = 0;
@@ -1280,7 +1280,7 @@ static VALUE binary_accessor_write(VALUE self, VALUE value, VALUE param_bit_offs
  */
 static int get_int_length(VALUE self)
 {
-  rb_funcall(self, id_method_allocate_buffer, 0);
+  rb_funcall(self, id_method_allocate_buffer_if_needed, 0);
   return (int)RSTRING_LEN(rb_ivar_get(self, id_ivar_buffer));
 }
 
@@ -1310,7 +1310,7 @@ static VALUE read_item_internal(VALUE self, VALUE item, VALUE buffer)
 
   if (!(RTEST(buffer)))
   {
-    buffer = rb_funcall(self, id_method_allocate_buffer, 0);
+    buffer = rb_funcall(self, id_method_allocate_buffer_if_needed, 0);
   }
   bit_offset = rb_ivar_get(item, id_ivar_bit_offset);
   bit_size = rb_ivar_get(item, id_ivar_bit_size);
@@ -1589,7 +1589,7 @@ static VALUE resize_buffer(VALUE self)
   }
   else
   {
-    rb_funcall(self, id_method_allocate_buffer, 0);
+    rb_funcall(self, id_method_allocate_buffer_if_needed, 0);
   }
 
   return self;
@@ -1617,7 +1617,7 @@ void Init_structure(void)
   id_method_Integer = rb_intern("Integer");
   id_method_Float = rb_intern("Float");
   id_method_kind_of = rb_intern("kind_of?");
-  id_method_allocate_buffer = rb_intern("allocate_buffer");
+  id_method_allocate_buffer_if_needed = rb_intern("allocate_buffer_if_needed");
 
   MIN_INT8 = INT2NUM(-128);
   MAX_INT8 = INT2NUM(127);

--- a/cosmos/lib/cosmos/packets/packet.rb
+++ b/cosmos/lib/cosmos/packets/packet.rb
@@ -98,7 +98,7 @@ module Cosmos
       # @param buffer [String] String buffer to hold the packet data
       # @param item_class [Class] Class used to instantiate items (Must be a
       #   subclass of PacketItem)
-      def initialize(target_name, packet_name, default_endianness = :BIG_ENDIAN, description = nil, buffer = '', item_class = PacketItem)
+      def initialize(target_name, packet_name, default_endianness = :BIG_ENDIAN, description = nil, buffer = nil, item_class = PacketItem)
         super(default_endianness, buffer, item_class)
         # Explictly call the defined setter methods
         self.target_name = target_name

--- a/cosmos/lib/cosmos/packets/structure.rb
+++ b/cosmos/lib/cosmos/packets/structure.rb
@@ -102,7 +102,7 @@ module Cosmos
       def read_item(item, value_type = :RAW, buffer = @buffer)
         return nil if item.data_type == :DERIVED
 
-        buffer = allocate_buffer() unless buffer
+        buffer = allocate_buffer_if_needed() unless buffer
         if item.array_size
           return BinaryAccessor.read_array(item.bit_offset, item.bit_size, item.data_type, item.array_size, buffer, item.endianness)
         else
@@ -114,7 +114,7 @@ module Cosmos
       #
       # @return [Integer] Size of the buffer in bytes
       def length
-        allocate_buffer()
+        allocate_buffer_if_needed()
         return @buffer.length
       end
 
@@ -126,7 +126,7 @@ module Cosmos
             @buffer << (ZERO_STRING * (@defined_length - @buffer.length))
           end
         else
-          allocate_buffer()
+          allocate_buffer_if_needed()
         end
 
         return self
@@ -134,7 +134,7 @@ module Cosmos
     end
 
     # Allocate a buffer if not available
-    def allocate_buffer
+    def allocate_buffer_if_needed
       unless @buffer
         @buffer = ZERO_STRING * @defined_length
         @buffer.force_encoding(ASCII_8BIT_STRING)
@@ -347,7 +347,7 @@ module Cosmos
     #   parameter to check whether to perform conversions on the item.
     # @param buffer [String] The binary buffer to write the value to
     def write_item(item, value, value_type = :RAW, buffer = @buffer)
-      buffer = allocate_buffer() unless buffer
+      buffer = allocate_buffer_if_needed() unless buffer
       if item.array_size
         BinaryAccessor.write_array(value, item.bit_offset, item.bit_size, item.data_type, item.array_size, buffer, item.endianness, item.overflow)
       else
@@ -436,7 +436,7 @@ module Cosmos
     # @param copy [TrueClass/FalseClass] Whether to copy the buffer
     # @return [String] Data buffer backing the structure
     def buffer(copy = true)
-      local_buffer = allocate_buffer()
+      local_buffer = allocate_buffer_if_needed()
       if copy
         return local_buffer.dup
       else

--- a/cosmos/spec/io/udp_sockets_spec.rb
+++ b/cosmos/spec/io/udp_sockets_spec.rb
@@ -98,6 +98,7 @@ module Cosmos
         expect(IO).to receive(:fast_select).at_least(:once).and_return([], nil)
         udp_read = UdpReadSocket.new(8889)
         expect { udp_read.read(2.0) }.to raise_error(Timeout::Error)
+        udp_read.close
       end
     end
   end
@@ -110,7 +111,7 @@ module Cosmos
         expect(udp.local_address.ip_port).to eql 8888
         udp.close
         if RUBY_ENGINE == 'ruby' # UDP multicast does not work in Jruby
-          udp = UdpReadWriteSocket.new(8888, '0.0.0.0', 0, '224.0.1.1')
+          udp = UdpReadWriteSocket.new(8888, '0.0.0.0', 1234, '224.0.1.1')
           expect(IPAddr.new_ntoh(udp.getsockopt(Socket::IPPROTO_IP, Socket::IP_MULTICAST_IF).data).to_s).to eql "0.0.0.0"
           udp.close
         end

--- a/cosmos/spec/packet_logs/packet_log_writer_spec.rb
+++ b/cosmos/spec/packet_logs/packet_log_writer_spec.rb
@@ -168,14 +168,14 @@ module Cosmos
         end
         plw.shutdown
         sleep 0.1
-        # Since we wrote about 5s we should see 3 separate cycles
+        # Since we wrote about 3s we should see 3 separate cycles
         expect(@files.keys.length).to eq 6
 
         # Monkey patch the constant back to the default
         # Fortify says Access Specifier Manipulation
         # but this is test code only
         LogWriter.__send__(:remove_const, :CYCLE_TIME_INTERVAL)
-        LogWriter.const_set(:CYCLE_TIME_INTERVAL, 2)
+        LogWriter.const_set(:CYCLE_TIME_INTERVAL, 10)
       end
 
       it "handles errors creating the log file" do

--- a/cosmos/spec/packets/structure_spec.rb
+++ b/cosmos/spec/packets/structure_spec.rb
@@ -350,10 +350,10 @@ module Cosmos
     end
 
     describe "read_item", no_ext: true do
-      it "complains if no buffer given" do
+      it "works if no buffer given" do
         s = Structure.new
         s.define_item("test1", 0, 8, :UINT)
-        expect { s.read_item(s.get_item("test1"), :RAW, nil) }.to raise_error(RuntimeError, "No buffer given to read_item")
+        expect(s.read_item(s.get_item("test1"), :RAW, nil)).to eql 0
       end
 
       it "reads data from the buffer" do
@@ -372,8 +372,11 @@ module Cosmos
     end
 
     describe "write_item" do
-      it "complains if no buffer given" do
-        expect { Structure.new.write_item(nil, nil, nil, nil) }.to raise_error(RuntimeError, "No buffer given to write_item")
+      it "works if no buffer given" do
+        s = Structure.new
+        s.define_item("test1", 0, 8, :UINT)
+        s.write_item(s.get_item("test1"), 1, :RAW, nil)
+        expect(s.read_item(s.get_item("test1"), :RAW, nil)).to eql 1
       end
 
       it "writes data to the buffer" do
@@ -647,11 +650,12 @@ module Cosmos
         expect(s.test1).to eql [3, 4]
       end
 
-      it "raises an exception if there is no buffer" do
+      it "works if there is no buffer" do
         s = Structure.new(:BIG_ENDIAN, nil)
         s.append_item("test1", 8, :UINT, 16)
         s.enable_method_missing
-        expect { s.test1 }.to raise_error(/No buffer/)
+        s.test1 = [5, 6]
+        expect(s.test1).to eql [5, 6]
       end
 
       it "complains if it can't find an item" do


### PR DESCRIPTION
Make all packet log writers share cycle thread.  With large numbers of packets, this makes a huge difference in the number of threads needed to run COSMOS.

Default packet buffer to nil.  This improves everywhere where a System is generated.  Packets will not allocate space for their buffers until needed.  Will greatly reduce RAM allocation in situations where there are large numbers of defined but unused packets.

Fix UDP multicast test on Mac.  Macs do not like Multicast specifying port 0.