### PR TITLE
Fix model initialization to pass needs_dependencies to correctly prop…

### DIFF
--- a/cosmos/lib/cosmos/models/interface_model.rb
+++ b/cosmos/lib/cosmos/models/interface_model.rb
@@ -60,7 +60,7 @@ module Cosmos
       case keyword
       when 'INTERFACE'
         parser.verify_num_parameters(2, nil, "INTERFACE <Name> <Filename> <Specific Parameters>")
-        return self.new(name: parameters[0].upcase, config_params: parameters[1..-1], plugin: plugin, scope: scope)
+        return self.new(name: parameters[0].upcase, config_params: parameters[1..-1], plugin: plugin, needs_dependencies: needs_dependencies, scope: scope)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Interface: #{keyword} #{parameters.join(" ")}")
       end

--- a/cosmos/lib/cosmos/models/microservice_model.rb
+++ b/cosmos/lib/cosmos/models/microservice_model.rb
@@ -63,7 +63,7 @@ module Cosmos
       when 'MICROSERVICE'
         parser.verify_num_parameters(2, 2, "#{keyword} <Folder Name> <Name>")
         # Create name by adding scope and type 'USER' to indicate where this microservice came from
-        return self.new(folder_name: parameters[0], name: "#{scope}__USER__#{parameters[1].upcase}", plugin: plugin, scope: scope)
+        return self.new(folder_name: parameters[0], name: "#{scope}__USER__#{parameters[1].upcase}", plugin: plugin, needs_dependencies: needs_dependencies, scope: scope)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Microservice: #{keyword} #{parameters.join(" ")}")
       end

--- a/cosmos/lib/cosmos/models/router_model.rb
+++ b/cosmos/lib/cosmos/models/router_model.rb
@@ -26,7 +26,7 @@ module Cosmos
       case keyword
       when 'ROUTER'
         parser.verify_num_parameters(2, nil, "ROUTER <Name> <Filename> <Specific Parameters>")
-        return self.new(name: parameters[0].upcase, config_params: parameters[1..-1], plugin: plugin, scope: scope)
+        return self.new(name: parameters[0].upcase, config_params: parameters[1..-1], plugin: plugin,  needs_dependencies: needs_dependencies, scope: scope)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Router: #{keyword} #{parameters.join(" ")}")
       end

--- a/cosmos/lib/cosmos/models/target_model.rb
+++ b/cosmos/lib/cosmos/models/target_model.rb
@@ -88,7 +88,7 @@ module Cosmos
       # If the key doesn't exist or if there are no packets we return empty array
       Store.hkeys("#{scope}__cosmos#{type.to_s.downcase}__#{target_name}").sort
     end
-
+  
     # @return [Hash] Packet hash or raises an exception
     def self.packet(target_name, packet_name, type: :TLM, scope:)
       raise "Unknown type #{type} for #{target_name} #{packet_name}" unless VALID_TYPES.include?(type)
@@ -170,7 +170,7 @@ module Cosmos
         usage = "#{keyword} <TARGET FOLDER NAME> <TARGET NAME>"
         parser.verify_num_parameters(2, 2, usage)
         parser.verify_parameter_naming(2) # Target name is the 2nd parameter
-        return self.new(name: parameters[1].to_s.upcase, folder_name: parameters[0].to_s.upcase, plugin: plugin, scope: scope)
+        return self.new(name: parameters[1].to_s.upcase, folder_name: parameters[0].to_s.upcase, plugin: plugin,  needs_dependencies: needs_dependencies, scope: scope)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Target: #{keyword} #{parameters.join(" ")}")
       end

--- a/cosmos/lib/cosmos/models/tool_model.rb
+++ b/cosmos/lib/cosmos/models/tool_model.rb
@@ -79,7 +79,7 @@ module Cosmos
       case keyword
       when 'TOOL'
         parser.verify_num_parameters(2, 2, "TOOL <Folder Name> <Name>")
-        return self.new(folder_name: parameters[0], name: parameters[1], plugin: plugin, scope: scope)
+        return self.new(folder_name: parameters[0], name: parameters[1], plugin: plugin, needs_dependencies: needs_dependencies, scope: scope)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Tool: #{keyword} #{parameters.join(" ")}")
       end

--- a/cosmos/lib/cosmos/models/widget_model.rb
+++ b/cosmos/lib/cosmos/models/widget_model.rb
@@ -69,7 +69,7 @@ module Cosmos
       case keyword
       when 'WIDGET'
         parser.verify_num_parameters(1, 1, "WIDGET <Name>")
-        return self.new(name: parameters[0], plugin: plugin, scope: scope)
+        return self.new(name: parameters[0], plugin: plugin, needs_dependencies: needs_dependencies, scope: scope)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Widget: #{keyword} #{parameters.join(" ")}")
       end


### PR DESCRIPTION
This pull request is a fix for #1731. Each of the updated models is initialized in `plugin_model.rb` at the line below

https://github.com/BallAerospace/COSMOS/blob/7e14868c27f51022479fb8ad87d3d1f9c12de35b/cosmos/lib/cosmos/models/plugin_model.rb#L207

For each of the models updated the `needs_dependencies` flag was not propagated to the underlying model initialization call. This results in the dependencies added with the `needs_dependenices` flag, including but not limited to a plugin level `lib` folder to be not included in the `$LOAD_PATH` for the microservices when they are launched. This in tern results in the `require` errors as documented in #1731.